### PR TITLE
新增 OAuth2 plugin 裡頭處理 Past-Client-Token 的設定配置

### DIFF
--- a/sa-token-plugin/sa-token-oauth2/src/main/java/cn/dev33/satoken/oauth2/config/SaOAuth2Config.java
+++ b/sa-token-plugin/sa-token-oauth2/src/main/java/cn/dev33/satoken/oauth2/config/SaOAuth2Config.java
@@ -42,6 +42,9 @@ public class SaOAuth2Config implements Serializable {
 	/** Client-Token 保存的时间(单位秒) 默认两个小时 */
 	public long clientTokenTimeout = 60 * 60 * 2;
 
+	/** Past-Client-Token 保存的时间(单位秒) 默认為 null */
+	public Long pastClientTokenTimeout = null;
+
 
 	/**
 	 * @return isCode
@@ -177,6 +180,22 @@ public class SaOAuth2Config implements Serializable {
 		return this;
 	}
 
+	/**
+	 * @return pastClientTokenTimeout
+	 */
+	public Long getPastClientTokenTimeout() {
+		return pastClientTokenTimeout;
+	}
+
+	/**
+	 * @param pastClientTokenTimeout 要设置的 pastClientTokenTimeout
+	 * @return 对象自身
+	 */
+	public SaOAuth2Config setPastClientTokenTimeout(long pastClientTokenTimeout) {
+		this.pastClientTokenTimeout = pastClientTokenTimeout;
+		return this;
+	}
+
 	
 	// -------------------- SaOAuth2Handle 所有回调函数 -------------------- 
 	
@@ -228,7 +247,8 @@ public class SaOAuth2Config implements Serializable {
 		return "SaOAuth2Config [isCode=" + isCode + ", isImplicit=" + isImplicit + ", isPassword=" + isPassword
 				+ ", isClient=" + isClient + ", isNewRefresh=" + isNewRefresh + ", codeTimeout=" + codeTimeout
 				+ ", accessTokenTimeout=" + accessTokenTimeout + ", refreshTokenTimeout=" + refreshTokenTimeout
-				+ ", clientTokenTimeout=" + clientTokenTimeout + "]";
+				+ ", clientTokenTimeout=" + clientTokenTimeout + ", pastClientTokenTimeout=" + pastClientTokenTimeout
+				+"]";
 	}
 	
 }

--- a/sa-token-plugin/sa-token-oauth2/src/main/java/cn/dev33/satoken/oauth2/logic/SaOAuth2Template.java
+++ b/sa-token-plugin/sa-token-oauth2/src/main/java/cn/dev33/satoken/oauth2/logic/SaOAuth2Template.java
@@ -598,7 +598,11 @@ public class SaOAuth2Template {
 		if(ct == null) {
 			return;
 		}
-		SaManager.getSaTokenDao().set(splicingPastTokenIndexKey(ct.clientId), ct.clientToken, ct.getExpiresIn());
+		Long ttl = ct.getExpiresIn();
+		if (null != SaOAuth2Manager.getConfig().getPastClientTokenTimeout()) {
+			ttl = SaOAuth2Manager.getConfig().getPastClientTokenTimeout();
+		}
+		SaManager.getSaTokenDao().set(splicingPastTokenIndexKey(ct.clientId), ct.clientToken, ttl);
 	}
 	/**
 	 * 持久化：用户授权记录


### PR DESCRIPTION
## 背景
在實務需求上，會很有機會需要讓前一個的 client token(credential mode) 並存，以處理異步的請求，但原有的行為則會間接允許相同的 client 簽發出兩個能同時被接受的 access token。

## 作法
參考 jwt-auth 設計的 [blacklist_grace_period](https://github.com/tymondesigns/jwt-auth/blob/develop/config/config.php#L238)，允許另外的設定去配置 pastClientToken 的 ttl 。

## 影響
- 當有刷新 token 時，會視設定內容去決定 past token 的存活時間。
- 在預設不調整的情境下，套件使用者也可保留原本的行為，不需做任何更改。