### PR TITLE
版本号统一管理

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>cn.dev33</groupId>
     <artifactId>sa-token-parent</artifactId>
 	<packaging>pom</packaging>
-	<version>1.29.1.trial</version>
+	<version>${revision}</version>
 	
 	<!-- 项目介绍 -->
 	<name>sa-token</name>
@@ -37,7 +37,7 @@
 	
 	<!-- 一些属性 -->
 	<properties>
-		<sa-token-version>1.29.1.trial</sa-token-version>
+		<revision>1.29.1.trial</revision>
         <jdk.version>1.8</jdk.version>
 		<project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>utf-8</project.reporting.outputEncoding>
@@ -86,6 +86,35 @@
 				<encoding>UTF-8</encoding>
 			</configuration>
 		</plugin>
+
+		<!-- 版本号管理 -->
+	   <plugin>
+		   <groupId>org.codehaus.mojo</groupId>
+		   <artifactId>flatten-maven-plugin</artifactId>
+		   <version>1.2.7</version>
+		   <configuration>
+			   <updatePomFile>true</updatePomFile>
+			   <flattenMode>resolveCiFriendliesOnly</flattenMode>
+		   </configuration>
+		   <executions>
+			   <execution>
+				   <id>flatten</id>
+				   <phase>process-resources</phase>
+				   <goals>
+					   <goal>flatten</goal>
+				   </goals>
+			   </execution>
+			   <execution>
+				   <id>flatten.clean</id>
+				   <phase>clean</phase>
+				   <goals>
+					   <goal>clean</goal>
+				   </goals>
+			   </execution>
+		   </executions>
+	   </plugin>
+
+
 	   </plugins>
 	   <pluginManagement>
 		   	<plugins>

--- a/sa-token-core/pom.xml
+++ b/sa-token-core/pom.xml
@@ -7,7 +7,8 @@
 	<parent>
         <groupId>cn.dev33</groupId>
         <artifactId>sa-token-parent</artifactId>
-        <version>1.29.1.trial</version>
+		<version>${revision}</version>
+		<relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>jar</packaging>
 

--- a/sa-token-plugin/pom.xml
+++ b/sa-token-plugin/pom.xml
@@ -7,7 +7,8 @@
 	<parent>
         <groupId>cn.dev33</groupId>
         <artifactId>sa-token-parent</artifactId>
-        <version>1.29.1.trial</version>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>pom</packaging>
     

--- a/sa-token-plugin/sa-token-alone-redis/pom.xml
+++ b/sa-token-plugin/sa-token-alone-redis/pom.xml
@@ -7,7 +7,8 @@
 	<parent>
         <groupId>cn.dev33</groupId>
         <artifactId>sa-token-plugin</artifactId>
-        <version>1.29.1.trial</version>
+		<version>${revision}</version>
+		<relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>jar</packaging>
 
@@ -20,13 +21,13 @@
 		<dependency>
             <groupId>cn.dev33</groupId>
             <artifactId>sa-token-dao-redis</artifactId>
-            <version>${sa-token-version}</version>
+            <version>${revision}</version>
 			<optional>true</optional>
         </dependency>
 		<dependency>
             <groupId>cn.dev33</groupId>
             <artifactId>sa-token-dao-redis-jackson</artifactId>
-            <version>${sa-token-version}</version>
+            <version>${revision}</version>
 			<optional>true</optional>
         </dependency>
         <!-- redis pool -->

--- a/sa-token-plugin/sa-token-context-dubbo/pom.xml
+++ b/sa-token-plugin/sa-token-context-dubbo/pom.xml
@@ -7,7 +7,8 @@
 	<parent>
         <groupId>cn.dev33</groupId>
         <artifactId>sa-token-plugin</artifactId>
-        <version>1.29.1.trial</version>
+		<version>${revision}</version>
+		<relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>jar</packaging>
 
@@ -20,7 +21,7 @@
 		<dependency>
             <groupId>cn.dev33</groupId>
             <artifactId>sa-token-core</artifactId>
-            <version>${sa-token-version}</version>
+            <version>${revision}</version>
         </dependency>
         
 		<!-- dubbo -->

--- a/sa-token-plugin/sa-token-dao-redis-jackson/pom.xml
+++ b/sa-token-plugin/sa-token-dao-redis-jackson/pom.xml
@@ -7,7 +7,8 @@
 	<parent>
         <groupId>cn.dev33</groupId>
         <artifactId>sa-token-plugin</artifactId>
-        <version>1.29.1.trial</version>
+		<version>${revision}</version>
+		<relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>jar</packaging>
 
@@ -20,7 +21,7 @@
 		<dependency>
             <groupId>cn.dev33</groupId>
             <artifactId>sa-token-core</artifactId>
-            <version>${sa-token-version}</version>
+            <version>${revision}</version>
         </dependency>
 		<!-- RedisTemplate 相关操作API -->
         <dependency>

--- a/sa-token-plugin/sa-token-dao-redis/pom.xml
+++ b/sa-token-plugin/sa-token-dao-redis/pom.xml
@@ -7,7 +7,8 @@
 	<parent>
         <groupId>cn.dev33</groupId>
         <artifactId>sa-token-plugin</artifactId>
-        <version>1.29.1.trial</version>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>jar</packaging>
 
@@ -20,7 +21,7 @@
 		<dependency>
             <groupId>cn.dev33</groupId>
             <artifactId>sa-token-core</artifactId>
-            <version>${sa-token-version}</version>
+            <version>${revision}</version>
         </dependency>
 		<!-- RedisTemplate 相关操作API -->
         <dependency>

--- a/sa-token-plugin/sa-token-dialect-thymeleaf/pom.xml
+++ b/sa-token-plugin/sa-token-dialect-thymeleaf/pom.xml
@@ -7,7 +7,8 @@
 	<parent>
         <groupId>cn.dev33</groupId>
         <artifactId>sa-token-plugin</artifactId>
-        <version>1.29.1.trial</version>
+		<version>${revision}</version>
+		<relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>jar</packaging>
 
@@ -20,7 +21,7 @@
 		<dependency>
             <groupId>cn.dev33</groupId>
             <artifactId>sa-token-core</artifactId>
-            <version>${sa-token-version}</version>
+            <version>${revision}</version>
         </dependency>
 		<!-- thymeleaf -->
 		<dependency>

--- a/sa-token-plugin/sa-token-jwt/pom.xml
+++ b/sa-token-plugin/sa-token-jwt/pom.xml
@@ -7,7 +7,8 @@
 	<parent>
         <groupId>cn.dev33</groupId>
         <artifactId>sa-token-plugin</artifactId>
-        <version>1.29.1.trial</version>
+		<version>${revision}</version>
+		<relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>jar</packaging>
 
@@ -20,7 +21,7 @@
 		<dependency>
             <groupId>cn.dev33</groupId>
             <artifactId>sa-token-core</artifactId>
-            <version>${sa-token-version}</version>
+            <version>${revision}</version>
         </dependency>
 		<!-- hutool (jwt) -->
         <dependency>

--- a/sa-token-plugin/sa-token-oauth2/pom.xml
+++ b/sa-token-plugin/sa-token-oauth2/pom.xml
@@ -7,7 +7,8 @@
 	<parent>
         <groupId>cn.dev33</groupId>
         <artifactId>sa-token-plugin</artifactId>
-        <version>1.29.1.trial</version>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>jar</packaging>
 
@@ -20,7 +21,7 @@
 		<dependency>
             <groupId>cn.dev33</groupId>
             <artifactId>sa-token-core</artifactId>
-            <version>${sa-token-version}</version>
+            <version>${revision}</version>
         </dependency>
 	</dependencies>
 

--- a/sa-token-plugin/sa-token-quick-login/pom.xml
+++ b/sa-token-plugin/sa-token-quick-login/pom.xml
@@ -7,7 +7,8 @@
 	<parent>
         <groupId>cn.dev33</groupId>
         <artifactId>sa-token-plugin</artifactId>
-        <version>1.29.1.trial</version>
+		<version>${revision}</version>
+		<relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>jar</packaging>
 
@@ -20,7 +21,7 @@
 		<dependency>
             <groupId>cn.dev33</groupId>
             <artifactId>sa-token-spring-boot-starter</artifactId>
-            <version>${sa-token-version}</version>
+            <version>${revision}</version>
         </dependency>
 		<!-- 视图引擎 -->
 		<dependency>

--- a/sa-token-plugin/sa-token-spring-aop/pom.xml
+++ b/sa-token-plugin/sa-token-spring-aop/pom.xml
@@ -7,7 +7,8 @@
 	<parent>
         <groupId>cn.dev33</groupId>
         <artifactId>sa-token-plugin</artifactId>
-        <version>1.29.1.trial</version>
+		<version>${revision}</version>
+		<relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>jar</packaging>
 
@@ -20,7 +21,7 @@
 		<dependency>
             <groupId>cn.dev33</groupId>
             <artifactId>sa-token-spring-boot-starter</artifactId>
-            <version>${sa-token-version}</version>
+            <version>${revision}</version>
         </dependency>
 		<!-- spring-boot-starter-aop -->
 		<dependency>

--- a/sa-token-plugin/sa-token-temp-jwt/pom.xml
+++ b/sa-token-plugin/sa-token-temp-jwt/pom.xml
@@ -7,7 +7,8 @@
 	<parent>
         <groupId>cn.dev33</groupId>
         <artifactId>sa-token-plugin</artifactId>
-        <version>1.29.1.trial</version>
+		<version>${revision}</version>
+		<relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>jar</packaging>
 
@@ -20,7 +21,7 @@
 		<dependency>
             <groupId>cn.dev33</groupId>
             <artifactId>sa-token-core</artifactId>
-            <version>${sa-token-version}</version>
+            <version>${revision}</version>
         </dependency>
 		<!-- jwt -->
         <dependency>

--- a/sa-token-starter/pom.xml
+++ b/sa-token-starter/pom.xml
@@ -7,7 +7,8 @@
 	<parent>
         <groupId>cn.dev33</groupId>
         <artifactId>sa-token-parent</artifactId>
-        <version>1.29.1.trial</version>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>pom</packaging>
     

--- a/sa-token-starter/sa-token-jboot-plugin/pom.xml
+++ b/sa-token-starter/sa-token-jboot-plugin/pom.xml
@@ -5,7 +5,8 @@
     <parent>
         <artifactId>sa-token-starter</artifactId>
         <groupId>cn.dev33</groupId>
-        <version>1.29.1.trial</version>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>
@@ -28,12 +29,12 @@
         <dependency>
             <groupId>cn.dev33</groupId>
             <artifactId>sa-token-core</artifactId>
-            <version>${sa-token-version}</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>cn.dev33</groupId>
             <artifactId>sa-token-servlet</artifactId>
-            <version>${sa-token-version}</version>
+            <version>${revision}</version>
         </dependency>
     </dependencies>
 

--- a/sa-token-starter/sa-token-jfinal-plugin/pom.xml
+++ b/sa-token-starter/sa-token-jfinal-plugin/pom.xml
@@ -5,7 +5,8 @@
     <parent>
         <artifactId>sa-token-starter</artifactId>
         <groupId>cn.dev33</groupId>
-        <version>1.29.1.trial</version>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>
@@ -37,12 +38,12 @@
         <dependency>
             <groupId>cn.dev33</groupId>
             <artifactId>sa-token-core</artifactId>
-            <version>${sa-token-version}</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>cn.dev33</groupId>
             <artifactId>sa-token-servlet</artifactId>
-            <version>${sa-token-version}</version>
+            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/sa-token-starter/sa-token-reactor-spring-boot-starter/pom.xml
+++ b/sa-token-starter/sa-token-reactor-spring-boot-starter/pom.xml
@@ -7,7 +7,8 @@
 	<parent>
         <groupId>cn.dev33</groupId>
         <artifactId>sa-token-starter</artifactId>
-        <version>1.29.1.trial</version>
+		<version>${revision}</version>
+		<relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>jar</packaging>
 
@@ -20,7 +21,7 @@
 		<dependency>
             <groupId>cn.dev33</groupId>
             <artifactId>sa-token-core</artifactId>
-            <version>${sa-token-version}</version>
+            <version>${revision}</version>
         </dependency>
 		<!-- spring-boot-starter -->
         <dependency>
@@ -47,7 +48,7 @@
 		<dependency>
 			<groupId>cn.dev33</groupId>
 			<artifactId>sa-token-oauth2</artifactId>
-            <version>${sa-token-version}</version>
+            <version>${revision}</version>
 			<optional>true</optional>
 		</dependency>
 		

--- a/sa-token-starter/sa-token-servlet/pom.xml
+++ b/sa-token-starter/sa-token-servlet/pom.xml
@@ -7,7 +7,8 @@
 	<parent>
         <groupId>cn.dev33</groupId>
         <artifactId>sa-token-starter</artifactId>
-        <version>1.29.1.trial</version>
+		<version>${revision}</version>
+		<relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>jar</packaging>
 
@@ -20,7 +21,7 @@
 		<dependency>
             <groupId>cn.dev33</groupId>
             <artifactId>sa-token-core</artifactId>
-            <version>${sa-token-version}</version>
+            <version>${revision}</version>
         </dependency>
         <!-- Servlet API -->
         <dependency>

--- a/sa-token-starter/sa-token-solon-plugin/pom.xml
+++ b/sa-token-starter/sa-token-solon-plugin/pom.xml
@@ -7,7 +7,8 @@
     <parent>
         <groupId>cn.dev33</groupId>
         <artifactId>sa-token-starter</artifactId>
-        <version>1.29.1.trial</version>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>jar</packaging>
 
@@ -25,7 +26,7 @@
         <dependency>
             <groupId>cn.dev33</groupId>
             <artifactId>sa-token-core</artifactId>
-            <version>${sa-token-version}</version>
+            <version>${revision}</version>
         </dependency>
 
     </dependencies>

--- a/sa-token-starter/sa-token-spring-boot-starter/pom.xml
+++ b/sa-token-starter/sa-token-spring-boot-starter/pom.xml
@@ -7,7 +7,8 @@
 	<parent>
         <groupId>cn.dev33</groupId>
         <artifactId>sa-token-starter</artifactId>
-        <version>1.29.1.trial</version>
+		<version>${revision}</version>
+		<relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>jar</packaging>
 
@@ -19,7 +20,7 @@
 		<dependency>
 			<groupId>cn.dev33</groupId>
 			<artifactId>sa-token-servlet</artifactId>
-            <version>${sa-token-version}</version>
+            <version>${revision}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -30,7 +31,7 @@
 		<dependency>
 			<groupId>cn.dev33</groupId>
 			<artifactId>sa-token-oauth2</artifactId>
-            <version>${sa-token-version}</version>
+            <version>${revision}</version>
 			<optional>true</optional>
 		</dependency>
 		<!-- config -->

--- a/sa-token-test/pom.xml
+++ b/sa-token-test/pom.xml
@@ -7,7 +7,8 @@
 	<parent>
         <groupId>cn.dev33</groupId>
         <artifactId>sa-token-parent</artifactId>
-        <version>1.29.1.trial</version>
+		<version>${revision}</version>
+		<relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>pom</packaging>
 

--- a/sa-token-test/sa-token-core-test/pom.xml
+++ b/sa-token-test/sa-token-core-test/pom.xml
@@ -7,7 +7,8 @@
 	<parent>
         <groupId>cn.dev33</groupId>
         <artifactId>sa-token-test</artifactId>
-        <version>1.29.1.trial</version>
+		<version>${revision}</version>
+		<relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>jar</packaging>
 
@@ -19,7 +20,7 @@
 		<dependency>
 			<groupId>cn.dev33</groupId>
 			<artifactId>sa-token-core</artifactId>
-            <version>${sa-token-version}</version>
+            <version>${revision}</version>
 		</dependency>
 	</dependencies>
 

--- a/sa-token-test/sa-token-jwt-test/pom.xml
+++ b/sa-token-test/sa-token-jwt-test/pom.xml
@@ -7,7 +7,8 @@
 	<parent>
         <groupId>cn.dev33</groupId>
         <artifactId>sa-token-test</artifactId>
-        <version>1.29.1.trial</version>
+		<version>${revision}</version>
+		<relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>jar</packaging>
 
@@ -19,12 +20,12 @@
 		<dependency>
 			<groupId>cn.dev33</groupId>
 			<artifactId>sa-token-spring-boot-starter</artifactId>
-            <version>${sa-token-version}</version>
+            <version>${revision}</version>
 		</dependency>
 		<dependency>
 			<groupId>cn.dev33</groupId>
 			<artifactId>sa-token-jwt</artifactId>
-            <version>${sa-token-version}</version>
+            <version>${revision}</version>
 		</dependency>
 	</dependencies>
 

--- a/sa-token-test/sa-token-springboot-integrate-test/pom.xml
+++ b/sa-token-test/sa-token-springboot-integrate-test/pom.xml
@@ -7,7 +7,8 @@
 	<parent>
         <groupId>cn.dev33</groupId>
         <artifactId>sa-token-test</artifactId>
-        <version>1.29.1.trial</version>
+		<version>${revision}</version>
+		<relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>jar</packaging>
 
@@ -19,7 +20,7 @@
 		<dependency>
 			<groupId>cn.dev33</groupId>
 			<artifactId>sa-token-spring-boot-starter</artifactId>
-            <version>${sa-token-version}</version>
+            <version>${revision}</version>
 		</dependency>
 	</dependencies>
 

--- a/sa-token-test/sa-token-springboot-test/pom.xml
+++ b/sa-token-test/sa-token-springboot-test/pom.xml
@@ -7,7 +7,8 @@
 	<parent>
         <groupId>cn.dev33</groupId>
         <artifactId>sa-token-test</artifactId>
-        <version>1.29.1.trial</version>
+		<version>${revision}</version>
+		<relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>jar</packaging>
 
@@ -19,7 +20,7 @@
 		<dependency>
 			<groupId>cn.dev33</groupId>
 			<artifactId>sa-token-spring-boot-starter</artifactId>
-            <version>${sa-token-version}</version>
+            <version>${revision}</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
本次PR主要针对框架子模块的版本号进行了统一的管理，该版本号管理方案参考 spring-boot 官方项目
由于项目的子模块较多，所有子模块版本号应该统一依赖于父模块的版本号
后续框架版本升级，只需修改父模块pom中的revision属性即可
![image](https://user-images.githubusercontent.com/24709538/156915680-4f7cfbee-6545-48cc-8b99-0143c88ec230.png)

本次提交只做了初步的版本号管理优化，最理想的状态应该再新建一个 sa-token-dependencies 用来统一管理所有引入的依赖，所有子模块引入的引来都不需要定义版本号，由这个dependencies模块来统一管理整个框架的版本号