### PR TITLE
增加parstToken未配置jwt密钥时的异常提示

### DIFF
--- a/sa-token-plugin/sa-token-jwt/src/main/java/cn/dev33/satoken/jwt/SaJwtUtil.java
+++ b/sa-token-plugin/sa-token-jwt/src/main/java/cn/dev33/satoken/jwt/SaJwtUtil.java
@@ -112,7 +112,9 @@ public class SaJwtUtil {
      * @return 解析后的jwt 对象 
      */
     public static JWT parseToken(String token, String keyt) {
-
+	// 秘钥不可以为空
+	SaTokenException.throwByNull(keyt, "请配置jwt秘钥");
+	
     	// 如果token为null 
     	if(token == null) {
     		throw NotLoginException.newInstance(null, NotLoginException.NOT_TOKEN);


### PR DESCRIPTION
测试jwt时发现报了一个莫名其妙的错误 不看源码查不出原因 原来是忘记配置jwt密钥了
![_5TS%ZV1AVG %L)WW7L9LBY](https://user-images.githubusercontent.com/45313304/159484310-647c52e1-e403-4fb2-8c4b-3e535b8155f0.png)
![@H1{HY_7MQ$822H{O%TUF6M](https://user-images.githubusercontent.com/45313304/159484253-8aa593ef-2d55-42c1-bb8a-6ef885c9eccd.png)
