### PR TITLE
Sa-Token 依赖包集中管理

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,139 @@
 		
 	</dependencies>
 	
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>cn.dev33</groupId>
+				<artifactId>sa-token-core</artifactId>
+				<version>${revision}</version>
+			</dependency>
+			
+			<!-- region sa-token-plugin -->
+			<dependency>
+				<groupId>cn.dev33</groupId>
+				<artifactId>sa-token-plugin</artifactId>
+				<version>${revision}</version>
+			</dependency>
+			<dependency>
+				<groupId>cn.dev33</groupId>
+				<artifactId>sa-token-alone-redis</artifactId>
+				<version>${revision}</version>
+			</dependency>
+			<dependency>
+				<groupId>cn.dev33</groupId>
+				<artifactId>sa-token-context-dubbo</artifactId>
+				<version>${revision}</version>
+			</dependency>
+			<dependency>
+				<groupId>cn.dev33</groupId>
+				<artifactId>sa-token-context-grpc</artifactId>
+				<version>${revision}</version>
+			</dependency>
+			<dependency>
+				<groupId>cn.dev33</groupId>
+				<artifactId>sa-token-dao-redis</artifactId>
+				<version>${revision}</version>
+			</dependency>
+			<dependency>
+				<groupId>cn.dev33</groupId>
+				<artifactId>sa-token-dao-redis-fastjson</artifactId>
+				<version>${revision}</version>
+			</dependency>
+			<dependency>
+				<groupId>cn.dev33</groupId>
+				<artifactId>sa-token-dao-redis-fastjson2</artifactId>
+				<version>${revision}</version>
+			</dependency>
+			<dependency>
+				<groupId>cn.dev33</groupId>
+				<artifactId>sa-token-dao-redis-jackson</artifactId>
+				<version>${revision}</version>
+			</dependency>
+			<dependency>
+				<groupId>cn.dev33</groupId>
+				<artifactId>sa-token-dao-redisx</artifactId>
+				<version>${revision}</version>
+			</dependency>
+			<dependency>
+				<groupId>cn.dev33</groupId>
+				<artifactId>sa-token-dialect-thymeleaf</artifactId>
+				<version>${revision}</version>
+			</dependency>
+			<dependency>
+				<groupId>cn.dev33</groupId>
+				<artifactId>sa-token-jwt</artifactId>
+				<version>${revision}</version>
+			</dependency>
+			<dependency>
+				<groupId>cn.dev33</groupId>
+				<artifactId>sa-token-oauth2</artifactId>
+				<version>${revision}</version>
+			</dependency>
+			<dependency>
+				<groupId>cn.dev33</groupId>
+				<artifactId>sa-token-quick-login</artifactId>
+				<version>${revision}</version>
+			</dependency>
+			<dependency>
+				<groupId>cn.dev33</groupId>
+				<artifactId>sa-token-spring-aop</artifactId>
+				<version>${revision}</version>
+			</dependency>
+			<dependency>
+				<groupId>cn.dev33</groupId>
+				<artifactId>sa-token-sso</artifactId>
+				<version>${revision}</version>
+			</dependency>
+			<dependency>
+				<groupId>cn.dev33</groupId>
+				<artifactId>sa-token-temp-jwt</artifactId>
+				<version>${revision}</version>
+			</dependency>
+			
+			<!-- endregion-->
+			
+			<!-- region sa-token-starter -->
+			<dependency>
+				<groupId>cn.dev33</groupId>
+				<artifactId>sa-token-starter</artifactId>
+				<version>${revision}</version>
+			</dependency>
+			<dependency>
+				<groupId>cn.dev33</groupId>
+				<artifactId>sa-token-jboot-plugin</artifactId>
+				<version>${revision}</version>
+			</dependency>
+			<dependency>
+				<groupId>cn.dev33</groupId>
+				<artifactId>sa-token-jfinal-plugin</artifactId>
+				<version>${revision}</version>
+			</dependency>
+			<dependency>
+				<groupId>cn.dev33</groupId>
+				<artifactId>sa-token-reactor-spring-boot-starter</artifactId>
+				<version>${revision}</version>
+			</dependency>
+			<dependency>
+				<groupId>cn.dev33</groupId>
+				<artifactId>sa-token-servlet</artifactId>
+				<version>${revision}</version>
+			</dependency>
+			<dependency>
+				<groupId>cn.dev33</groupId>
+				<artifactId>sa-token-solon-plugin</artifactId>
+				<version>${revision}</version>
+			</dependency>
+			<dependency>
+				<groupId>cn.dev33</groupId>
+				<artifactId>sa-token-spring-boot-starter</artifactId>
+				<version>${revision}</version>
+			</dependency>
+			<!-- endregion-->
+		
+		</dependencies>
+	</dependencyManagement>
+	
 	<!-- 项目构建 -->
 	<build>
 	   <plugins>

--- a/sa-token-plugin/sa-token-alone-redis/pom.xml
+++ b/sa-token-plugin/sa-token-alone-redis/pom.xml
@@ -21,25 +21,21 @@
 		<dependency>
             <groupId>cn.dev33</groupId>
             <artifactId>sa-token-dao-redis</artifactId>
-            <version>${revision}</version>
 			<optional>true</optional>
         </dependency>
 		<dependency>
             <groupId>cn.dev33</groupId>
             <artifactId>sa-token-dao-redis-jackson</artifactId>
-            <version>${revision}</version>
 			<optional>true</optional>
         </dependency>
 		<dependency>
             <groupId>cn.dev33</groupId>
             <artifactId>sa-token-dao-redis-fastjson</artifactId>
-            <version>${revision}</version>
 			<optional>true</optional>
         </dependency>
 		<dependency>
             <groupId>cn.dev33</groupId>
             <artifactId>sa-token-dao-redis-fastjson2</artifactId>
-            <version>${revision}</version>
 			<optional>true</optional>
         </dependency>
         <!-- redis pool -->

--- a/sa-token-plugin/sa-token-context-grpc/pom.xml
+++ b/sa-token-plugin/sa-token-context-grpc/pom.xml
@@ -29,7 +29,6 @@
         <dependency>
             <groupId>cn.dev33</groupId>
             <artifactId>sa-token-core</artifactId>
-            <version>${revision}</version>
         </dependency>
     </dependencies>
 </project>

--- a/sa-token-plugin/sa-token-dao-redis-fastjson/pom.xml
+++ b/sa-token-plugin/sa-token-dao-redis-fastjson/pom.xml
@@ -17,7 +17,6 @@
         <dependency>
             <groupId>cn.dev33</groupId>
             <artifactId>sa-token-core</artifactId>
-            <version>${revision}</version>
         </dependency>
         <!-- RedisTemplate 相关操作API -->
         <dependency>

--- a/sa-token-plugin/sa-token-dao-redis-fastjson2/pom.xml
+++ b/sa-token-plugin/sa-token-dao-redis-fastjson2/pom.xml
@@ -17,7 +17,6 @@
         <dependency>
             <groupId>cn.dev33</groupId>
             <artifactId>sa-token-core</artifactId>
-            <version>${revision}</version>
         </dependency>
         <!-- RedisTemplate 相关操作API -->
         <dependency>

--- a/sa-token-plugin/sa-token-dao-redis-jackson/pom.xml
+++ b/sa-token-plugin/sa-token-dao-redis-jackson/pom.xml
@@ -21,7 +21,6 @@
 		<dependency>
             <groupId>cn.dev33</groupId>
             <artifactId>sa-token-core</artifactId>
-            <version>${revision}</version>
         </dependency>
 		<!-- RedisTemplate 相关操作API -->
         <dependency>

--- a/sa-token-plugin/sa-token-dao-redis/pom.xml
+++ b/sa-token-plugin/sa-token-dao-redis/pom.xml
@@ -21,7 +21,6 @@
 		<dependency>
             <groupId>cn.dev33</groupId>
             <artifactId>sa-token-core</artifactId>
-            <version>${revision}</version>
         </dependency>
 		<!-- RedisTemplate 相关操作API -->
         <dependency>

--- a/sa-token-plugin/sa-token-dao-redisx/pom.xml
+++ b/sa-token-plugin/sa-token-dao-redisx/pom.xml
@@ -21,7 +21,6 @@
 		<dependency>
             <groupId>cn.dev33</groupId>
             <artifactId>sa-token-core</artifactId>
-        	<version>${revision}</version>
         </dependency>
 
         <dependency>

--- a/sa-token-plugin/sa-token-dialect-thymeleaf/pom.xml
+++ b/sa-token-plugin/sa-token-dialect-thymeleaf/pom.xml
@@ -21,7 +21,6 @@
 		<dependency>
             <groupId>cn.dev33</groupId>
             <artifactId>sa-token-core</artifactId>
-            <version>${revision}</version>
         </dependency>
 		<!-- thymeleaf -->
 		<dependency>

--- a/sa-token-plugin/sa-token-jwt/pom.xml
+++ b/sa-token-plugin/sa-token-jwt/pom.xml
@@ -21,7 +21,6 @@
 		<dependency>
             <groupId>cn.dev33</groupId>
             <artifactId>sa-token-core</artifactId>
-            <version>${revision}</version>
         </dependency>
 		<!-- hutool (jwt) -->
         <dependency>

--- a/sa-token-plugin/sa-token-oauth2/pom.xml
+++ b/sa-token-plugin/sa-token-oauth2/pom.xml
@@ -21,7 +21,6 @@
 		<dependency>
             <groupId>cn.dev33</groupId>
             <artifactId>sa-token-core</artifactId>
-            <version>${revision}</version>
         </dependency>
 	</dependencies>
 

--- a/sa-token-plugin/sa-token-quick-login/pom.xml
+++ b/sa-token-plugin/sa-token-quick-login/pom.xml
@@ -21,7 +21,6 @@
 		<dependency>
             <groupId>cn.dev33</groupId>
             <artifactId>sa-token-spring-boot-starter</artifactId>
-            <version>${revision}</version>
         </dependency>
 		<!-- 视图引擎 -->
 		<dependency>

--- a/sa-token-plugin/sa-token-spring-aop/pom.xml
+++ b/sa-token-plugin/sa-token-spring-aop/pom.xml
@@ -21,7 +21,6 @@
 		<dependency>
             <groupId>cn.dev33</groupId>
             <artifactId>sa-token-core</artifactId>
-            <version>${revision}</version>
         </dependency>
 		<!-- spring-boot-starter-aop -->
 		<dependency>

--- a/sa-token-plugin/sa-token-sso/pom.xml
+++ b/sa-token-plugin/sa-token-sso/pom.xml
@@ -21,7 +21,6 @@
 		<dependency>
             <groupId>cn.dev33</groupId>
             <artifactId>sa-token-core</artifactId>
-            <version>${revision}</version>
         </dependency>
 	</dependencies>
 

--- a/sa-token-plugin/sa-token-temp-jwt/pom.xml
+++ b/sa-token-plugin/sa-token-temp-jwt/pom.xml
@@ -21,7 +21,6 @@
 		<dependency>
             <groupId>cn.dev33</groupId>
             <artifactId>sa-token-core</artifactId>
-            <version>${revision}</version>
         </dependency>
 		<!-- jwt -->
         <dependency>

--- a/sa-token-starter/sa-token-jboot-plugin/pom.xml
+++ b/sa-token-starter/sa-token-jboot-plugin/pom.xml
@@ -30,12 +30,10 @@
         <dependency>
             <groupId>cn.dev33</groupId>
             <artifactId>sa-token-core</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>cn.dev33</groupId>
             <artifactId>sa-token-servlet</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>redis.clients</groupId>

--- a/sa-token-starter/sa-token-jfinal-plugin/pom.xml
+++ b/sa-token-starter/sa-token-jfinal-plugin/pom.xml
@@ -38,12 +38,10 @@
         <dependency>
             <groupId>cn.dev33</groupId>
             <artifactId>sa-token-core</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>cn.dev33</groupId>
             <artifactId>sa-token-servlet</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/sa-token-starter/sa-token-reactor-spring-boot-starter/pom.xml
+++ b/sa-token-starter/sa-token-reactor-spring-boot-starter/pom.xml
@@ -21,7 +21,6 @@
 		<dependency>
             <groupId>cn.dev33</groupId>
             <artifactId>sa-token-core</artifactId>
-            <version>${revision}</version>
         </dependency>
         
 		<!-- spring-boot-starter (optional) -->
@@ -68,7 +67,6 @@
 		<dependency>
 			<groupId>cn.dev33</groupId>
 			<artifactId>sa-token-oauth2</artifactId>
-            <version>${revision}</version>
 			<optional>true</optional>
 		</dependency>
 		
@@ -76,7 +74,6 @@
 		<dependency>
 			<groupId>cn.dev33</groupId>
 			<artifactId>sa-token-sso</artifactId>
-            <version>${revision}</version>
 			<optional>true</optional>
 		</dependency>
 		

--- a/sa-token-starter/sa-token-servlet/pom.xml
+++ b/sa-token-starter/sa-token-servlet/pom.xml
@@ -21,7 +21,6 @@
 		<dependency>
             <groupId>cn.dev33</groupId>
             <artifactId>sa-token-core</artifactId>
-            <version>${revision}</version>
         </dependency>
         
         <!-- Servlet API (optional) -->

--- a/sa-token-starter/sa-token-solon-plugin/pom.xml
+++ b/sa-token-starter/sa-token-solon-plugin/pom.xml
@@ -20,7 +20,6 @@
         <dependency>
             <groupId>cn.dev33</groupId>
             <artifactId>sa-token-core</artifactId>
-            <version>${revision}</version>
         </dependency>
     
         <dependency>

--- a/sa-token-starter/sa-token-spring-boot-starter/pom.xml
+++ b/sa-token-starter/sa-token-spring-boot-starter/pom.xml
@@ -21,7 +21,6 @@
 		<dependency>
 			<groupId>cn.dev33</groupId>
 			<artifactId>sa-token-servlet</artifactId>
-            <version>${revision}</version>
 		</dependency>
 		
 		<!-- spring-boot-starter-web (optional) -->
@@ -43,7 +42,6 @@
 		<dependency>
 			<groupId>cn.dev33</groupId>
 			<artifactId>sa-token-oauth2</artifactId>
-            <version>${revision}</version>
 			<optional>true</optional>
 		</dependency>
 		
@@ -51,7 +49,6 @@
 		<dependency>
 			<groupId>cn.dev33</groupId>
 			<artifactId>sa-token-sso</artifactId>
-            <version>${revision}</version>
 			<optional>true</optional>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
修复 #229
由于项目目录已经定型,这里采用改造最小的方式 , 将Sa-Token内部的模块版本统一在sa-token-parent模块中维护 , Sa-Token内部模块互相引用无需再定义版本号 , 例如:
```java
<dependency>
	<groupId>cn.dev33</groupId>
	<artifactId>sa-token-core</artifactId>
</dependency>
```
