### PR TITLE
增加配置路由和动态路由

### DIFF
--- a/sa-token-starter/pom.xml
+++ b/sa-token-starter/pom.xml
@@ -3,7 +3,7 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-   
+
 	<parent>
         <groupId>cn.dev33</groupId>
         <artifactId>sa-token-parent</artifactId>
@@ -11,11 +11,11 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>pom</packaging>
-    
+
 	<name>sa-token-starter</name>
     <artifactId>sa-token-starter</artifactId>
 	<description>sa-token starters</description>
-	
+
 	<!-- 所有子模块 -->
     <modules>
         <module>sa-token-servlet</module>
@@ -28,6 +28,7 @@
         <module>sa-token-solon-plugin</module>
         <module>sa-token-jboot-plugin</module>
         <module>sa-token-jfinal-plugin</module>
+        <module>sa-token-spring-cloud-config-starter</module>
     </modules>
 
 </project>

--- a/sa-token-starter/sa-token-spring-boot-autoconfig/src/main/java/cn/dev33/satoken/config/SaRouterConfig.java
+++ b/sa-token-starter/sa-token-spring-boot-autoconfig/src/main/java/cn/dev33/satoken/config/SaRouterConfig.java
@@ -1,6 +1,7 @@
 package cn.dev33.satoken.config;
 
 import java.io.Serializable;
+import java.util.Arrays;
 
 /**
  * 路由配置
@@ -15,7 +16,7 @@ public class SaRouterConfig implements Serializable {
   private static final long serialVersionUID = 6457701626541613685L;
 
   /**
-   * Enable
+   * 是否开启配置路由
    */
   private Boolean enable;
 
@@ -40,4 +41,11 @@ public class SaRouterConfig implements Serializable {
     this.rules = rules;
   }
 
+  @Override
+  public String toString() {
+    return "SaRouterConfig{" +
+        "enable=" + enable +
+        ", rules=" + Arrays.toString(rules) +
+        '}';
+  }
 }

--- a/sa-token-starter/sa-token-spring-boot-autoconfig/src/main/java/cn/dev33/satoken/config/SaRouterConfig.java
+++ b/sa-token-starter/sa-token-spring-boot-autoconfig/src/main/java/cn/dev33/satoken/config/SaRouterConfig.java
@@ -1,0 +1,43 @@
+package cn.dev33.satoken.config;
+
+import java.io.Serializable;
+
+/**
+ * 路由配置
+ * <p>
+ * 搭配配置中心使用 @EnableDynamicRouter 实现动态路由
+ *
+ * @author einsitang
+ */
+public class SaRouterConfig implements Serializable {
+
+
+  private static final long serialVersionUID = 6457701626541613685L;
+
+  /**
+   * Enable
+   */
+  private Boolean enable;
+
+  /**
+   * 路由规则
+   */
+  private SaRouterRule[] rules;
+
+  public Boolean getEnable() {
+    return enable;
+  }
+
+  public void setEnable(Boolean enable) {
+    this.enable = enable;
+  }
+
+  public SaRouterRule[] getRules() {
+    return this.rules;
+  }
+
+  public void setRules(SaRouterRule[] rules) {
+    this.rules = rules;
+  }
+
+}

--- a/sa-token-starter/sa-token-spring-boot-autoconfig/src/main/java/cn/dev33/satoken/config/SaRouterRule.java
+++ b/sa-token-starter/sa-token-spring-boot-autoconfig/src/main/java/cn/dev33/satoken/config/SaRouterRule.java
@@ -3,6 +3,11 @@ package cn.dev33.satoken.config;
 import java.io.Serializable;
 import java.util.Arrays;
 
+/**
+ * 路由规则
+ *
+ * @author einsitang
+ */
 public class SaRouterRule implements Serializable {
 
 

--- a/sa-token-starter/sa-token-spring-boot-autoconfig/src/main/java/cn/dev33/satoken/config/SaRouterRule.java
+++ b/sa-token-starter/sa-token-spring-boot-autoconfig/src/main/java/cn/dev33/satoken/config/SaRouterRule.java
@@ -1,0 +1,67 @@
+package cn.dev33.satoken.config;
+
+import java.io.Serializable;
+import java.util.Arrays;
+
+public class SaRouterRule implements Serializable {
+
+
+  private static final long serialVersionUID = -657275926804055868L;
+
+  private String[] match;
+
+  private String[] notMatch;
+
+  private String[] matchMethod;
+
+  private String[] notMatchMethod;
+
+  private SaRouterRuleCheck check;
+
+  public String[] getMatch() {
+    return match;
+  }
+
+  public void setMatch(String[] match) {
+    this.match = match;
+  }
+
+  public String[] getNotMatch() {
+    return notMatch;
+  }
+
+  public void setNotMatch(String[] notMatch) {
+    this.notMatch = notMatch;
+  }
+
+  public String[] getMatchMethod() {
+    return matchMethod;
+  }
+
+  public void setMatchMethod(String[] matchMethod) {
+    this.matchMethod = matchMethod;
+  }
+
+  public String[] getNotMatchMethod() {
+    return notMatchMethod;
+  }
+
+  public void setNotMatchMethod(String[] notMatchMethod) {
+    this.notMatchMethod = notMatchMethod;
+  }
+
+  public SaRouterRuleCheck getCheck() {
+    return check;
+  }
+
+  public void setCheck(SaRouterRuleCheck check) {
+    this.check = check;
+  }
+
+  @Override
+  public String toString() {
+    return "SaRouterRule{" + "match=" + Arrays.toString(match) + ", notMatch=" + Arrays.toString(
+        notMatch) + ", matchMethod=" + Arrays.toString(matchMethod) + ", notMatchMethod="
+        + Arrays.toString(notMatchMethod) + ", check=" + check + '}';
+  }
+}

--- a/sa-token-starter/sa-token-spring-boot-autoconfig/src/main/java/cn/dev33/satoken/config/SaRouterRuleCheck.java
+++ b/sa-token-starter/sa-token-spring-boot-autoconfig/src/main/java/cn/dev33/satoken/config/SaRouterRuleCheck.java
@@ -2,8 +2,12 @@ package cn.dev33.satoken.config;
 
 import java.io.Serializable;
 import java.util.Arrays;
-import java.util.List;
 
+/**
+ * 规则检查器
+ *
+ * @author einsitang
+ */
 public class SaRouterRuleCheck implements Serializable {
 
   private static final long serialVersionUID = 6002708589740924351L;
@@ -33,7 +37,7 @@ public class SaRouterRuleCheck implements Serializable {
    */
   private Boolean loginRequired = Boolean.TRUE;
 
-  public static SaRouterRuleCheck defaultChecker(){
+  public static SaRouterRuleCheck defaultChecker() {
     return new SaRouterRuleCheck();
   }
 

--- a/sa-token-starter/sa-token-spring-boot-autoconfig/src/main/java/cn/dev33/satoken/config/SaRouterRuleCheck.java
+++ b/sa-token-starter/sa-token-spring-boot-autoconfig/src/main/java/cn/dev33/satoken/config/SaRouterRuleCheck.java
@@ -1,0 +1,90 @@
+package cn.dev33.satoken.config;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+
+public class SaRouterRuleCheck implements Serializable {
+
+  private static final long serialVersionUID = 6002708589740924351L;
+
+  /**
+   * 检查角色列表,逻辑关系: AND
+   */
+  private String[] roles;
+
+  /**
+   * 检查权限列表,逻辑关系: AND
+   */
+  private String[] permissions;
+
+  /**
+   * 检查角色列表,逻辑关系: OR
+   */
+  private String[] rolesOr;
+
+  /**
+   * 检查权限列表,逻辑关系: OR
+   */
+  private String[] permissionsOr;
+
+  /**
+   * 检查是否登录,默认TRUE
+   */
+  private Boolean loginRequired = Boolean.TRUE;
+
+  public static SaRouterRuleCheck defaultChecker(){
+    return new SaRouterRuleCheck();
+  }
+
+  public String[] getRoles() {
+    return roles;
+  }
+
+  public void setRoles(String[] roles) {
+    this.roles = roles;
+  }
+
+  public String[] getPermissions() {
+    return permissions;
+  }
+
+  public void setPermissions(String[] permissions) {
+    this.permissions = permissions;
+  }
+
+  public String[] getRolesOr() {
+    return rolesOr;
+  }
+
+  public void setRolesOr(String[] rolesOr) {
+    this.rolesOr = rolesOr;
+  }
+
+  public String[] getPermissionsOr() {
+    return permissionsOr;
+  }
+
+  public void setPermissionsOr(String[] permissionsOr) {
+    this.permissionsOr = permissionsOr;
+  }
+
+  public Boolean getLoginRequired() {
+    return loginRequired;
+  }
+
+  public void setLoginRequired(Boolean loginRequired) {
+    this.loginRequired = loginRequired;
+  }
+
+  @Override
+  public String toString() {
+    return "SaRouterRuleCheck{" +
+        "roles=" + Arrays.toString(roles) +
+        ", permissions=" + Arrays.toString(permissions) +
+        ", rolesOr=" + Arrays.toString(rolesOr) +
+        ", permissionsOr=" + Arrays.toString(permissionsOr) +
+        ", loginRequired=" + loginRequired +
+        '}';
+  }
+}

--- a/sa-token-starter/sa-token-spring-boot-autoconfig/src/main/java/cn/dev33/satoken/spring/SaBeanRegister.java
+++ b/sa-token-starter/sa-token-spring-boot-autoconfig/src/main/java/cn/dev33/satoken/spring/SaBeanRegister.java
@@ -15,40 +15,51 @@
  */
 package cn.dev33.satoken.spring;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.Bean;
-
+import cn.dev33.satoken.config.SaRouterConfig;
 import cn.dev33.satoken.config.SaTokenConfig;
 import cn.dev33.satoken.json.SaJsonTemplate;
 import cn.dev33.satoken.spring.json.SaJsonTemplateForJackson;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 
 /**
- * 注册Sa-Token所需要的Bean 
- * <p> Bean 的注册与注入应该分开在两个文件中，否则在某些场景下会造成循环依赖 
- * @author click33
+ * 注册Sa-Token所需要的Bean
+ * <p> Bean 的注册与注入应该分开在两个文件中，否则在某些场景下会造成循环依赖
  *
+ * @author click33
  */
 public class SaBeanRegister {
 
-	/**
-	 * 获取配置Bean
-	 * 
-	 * @return 配置对象
-	 */
-	@Bean
-	@ConfigurationProperties(prefix = "sa-token")
-	public SaTokenConfig getSaTokenConfig() {
-		return new SaTokenConfig();
-	}
-	
-	/**
-	 * 获取 json 转换器 Bean (Jackson版)
-	 * 
-	 * @return json 转换器 Bean (Jackson版)
-	 */
-	@Bean
-	public SaJsonTemplate getSaJsonTemplateForJackson() {
-		return new SaJsonTemplateForJackson();
-	}
-	
+  /**
+   * 获取配置Bean
+   *
+   * @return 配置对象
+   */
+  @Bean
+  @ConfigurationProperties(prefix = "sa-token")
+  public SaTokenConfig getSaTokenConfig() {
+    return new SaTokenConfig();
+  }
+
+  /**
+   * 获取路由配置Bean
+   *
+   * @return 路由配置对象
+   */
+  @Bean
+  @ConfigurationProperties(prefix = "sa-token.router")
+  public SaRouterConfig getSaRouterConfig() {
+    return new SaRouterConfig();
+  }
+
+  /**
+   * 获取 json 转换器 Bean (Jackson版)
+   *
+   * @return json 转换器 Bean (Jackson版)
+   */
+  @Bean
+  public SaJsonTemplate getSaJsonTemplateForJackson() {
+    return new SaJsonTemplateForJackson();
+  }
+
 }

--- a/sa-token-starter/sa-token-spring-boot-autoconfig/src/main/java/cn/dev33/satoken/spring/SaDynamicRouterExecutor.java
+++ b/sa-token-starter/sa-token-spring-boot-autoconfig/src/main/java/cn/dev33/satoken/spring/SaDynamicRouterExecutor.java
@@ -1,0 +1,99 @@
+package cn.dev33.satoken.spring;
+
+import cn.dev33.satoken.config.SaRouterRule;
+import cn.dev33.satoken.config.SaRouterRuleCheck;
+import cn.dev33.satoken.router.SaRouter;
+import cn.dev33.satoken.router.SaRouterStaff;
+import cn.dev33.satoken.stp.StpUtil;
+
+/**
+ * 动态路由执行器
+ *
+ * @author einsitang
+ */
+public class SaDynamicRouterExecutor {
+
+  /**
+   * 是否启动
+   */
+  private boolean enable;
+
+  /**
+   * 路由规则
+   */
+  private SaRouterRule[] rules;
+
+  /**
+   * 重置规则，可以搭配SpringCloud进一步实现热更新动态路由配置
+   *
+   * @param enable 是否启动
+   * @param rules  SaRouterRule[]
+   */
+  public void reset(Boolean enable, SaRouterRule[] rules) {
+    this.enable = Boolean.TRUE.equals(enable);
+    if (rules == null || rules.length == 0) {
+      return;
+    }
+    this.rules = rules;
+
+  }
+
+  public void execute() {
+    if (!this.enable) {
+      return;
+    }
+    if (rules == null) {
+      return;
+    }
+    for (SaRouterRule rule : rules) {
+      executeRule(rule);
+    }
+  }
+
+  private void executeRule(SaRouterRule rule) {
+    String[] match, notMatch, matchMethod, notMatchMethod;
+    match = rule.getMatch();
+    notMatch = rule.getNotMatch();
+    matchMethod = rule.getMatchMethod();
+    notMatchMethod = rule.getNotMatchMethod();
+    SaRouterStaff staff = SaRouter.newMatch();
+    SaRouterRuleCheck checker = rule.getCheck();
+    if (match != null) {
+      staff = staff.match(match);
+    }
+    if (notMatch != null) {
+      staff.notMatch(notMatch);
+    }
+
+    if (matchMethod != null) {
+      staff.matchMethod(matchMethod);
+    }
+    if (notMatchMethod != null) {
+      staff.notMatchMethod(notMatchMethod);
+    }
+    if (checker == null) {
+      checker = SaRouterRuleCheck.defaultChecker();
+    }
+
+    SaRouterRuleCheck finalChecker = checker;
+    staff.check(r -> {
+      if (Boolean.TRUE.equals(finalChecker.getLoginRequired())) {
+        StpUtil.checkLogin();
+      }
+      if (finalChecker.getRoles() != null) {
+        StpUtil.checkRoleAnd(finalChecker.getRoles());
+      }
+      if (finalChecker.getRolesOr() != null) {
+        StpUtil.checkRoleOr(finalChecker.getRolesOr());
+      }
+      if (finalChecker.getPermissions() != null) {
+        StpUtil.checkPermissionAnd(finalChecker.getPermissions());
+      }
+      if (finalChecker.getPermissionsOr() != null) {
+        StpUtil.checkPermissionOr(finalChecker.getPermissionsOr());
+      }
+    });
+
+  }
+
+}

--- a/sa-token-starter/sa-token-spring-boot-autoconfig/src/main/java/cn/dev33/satoken/spring/SaDynamicRouterRegister.java
+++ b/sa-token-starter/sa-token-spring-boot-autoconfig/src/main/java/cn/dev33/satoken/spring/SaDynamicRouterRegister.java
@@ -4,7 +4,7 @@ import cn.dev33.satoken.config.SaRouterConfig;
 import org.springframework.context.annotation.Bean;
 
 /**
- * 当且仅当 sa-token.router.enable=true 时初始化动态路由执行器
+ * 注册动态路由执行器
  *
  * @author einsitang
  */

--- a/sa-token-starter/sa-token-spring-boot-autoconfig/src/main/java/cn/dev33/satoken/spring/SaDynamicRouterRegister.java
+++ b/sa-token-starter/sa-token-spring-boot-autoconfig/src/main/java/cn/dev33/satoken/spring/SaDynamicRouterRegister.java
@@ -1,0 +1,20 @@
+package cn.dev33.satoken.spring;
+
+import cn.dev33.satoken.config.SaRouterConfig;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * 当且仅当 sa-token.router.enable=true 时初始化动态路由执行器
+ *
+ * @author einsitang
+ */
+public class SaDynamicRouterRegister {
+
+  @Bean
+  public SaDynamicRouterExecutor dynamicRouterExecutor(SaRouterConfig routerConfig) {
+    SaDynamicRouterExecutor executor = new SaDynamicRouterExecutor();
+    executor.reset(routerConfig.getEnable(), routerConfig.getRules());
+    return executor;
+  }
+
+}

--- a/sa-token-starter/sa-token-spring-boot-autoconfig/src/main/resources/META-INF/spring.factories
+++ b/sa-token-starter/sa-token-spring-boot-autoconfig/src/main/resources/META-INF/spring.factories
@@ -1,6 +1,7 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 cn.dev33.satoken.spring.SaBeanRegister,\
 cn.dev33.satoken.spring.SaBeanInject,\
+cn.dev33.satoken.spring.SaDynamicRouterRegister,\
 cn.dev33.satoken.spring.sso.SaSsoBeanRegister,\
 cn.dev33.satoken.spring.sso.SaSsoBeanInject,\
 cn.dev33.satoken.spring.oauth2.SaOAuth2BeanRegister,\

--- a/sa-token-starter/sa-token-spring-boot-autoconfig/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/sa-token-starter/sa-token-spring-boot-autoconfig/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,5 +1,6 @@
 cn.dev33.satoken.spring.SaBeanRegister
 cn.dev33.satoken.spring.SaBeanInject
+cn.dev33.satoken.spring.SaDynamicRouterRegister
 cn.dev33.satoken.spring.sso.SaSsoBeanRegister
 cn.dev33.satoken.spring.sso.SaSsoBeanInject
 cn.dev33.satoken.spring.oauth2.SaOAuth2BeanRegister

--- a/sa-token-starter/sa-token-spring-boot-starter/pom.xml
+++ b/sa-token-starter/sa-token-spring-boot-starter/pom.xml
@@ -3,7 +3,7 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	
+
 	<parent>
         <groupId>cn.dev33</groupId>
         <artifactId>sa-token-starter</artifactId>
@@ -22,26 +22,26 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
-		
+
 		<!-- config (optional) -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>
 		</dependency>
-		
+
 		<!-- sa-token-servlet -->
 		<dependency>
 			<groupId>cn.dev33</groupId>
 			<artifactId>sa-token-servlet</artifactId>
 		</dependency>
-		
+
 		<!-- sa-token-spring-boot-autoconfig -->
 		<dependency>
 			<groupId>cn.dev33</groupId>
 			<artifactId>sa-token-spring-boot-autoconfig</artifactId>
 		</dependency>
-		
+
 	</dependencies>
 
 

--- a/sa-token-starter/sa-token-spring-boot-starter/src/main/java/cn/dev33/satoken/spring/SaTokenInterceptorRegister.java
+++ b/sa-token-starter/sa-token-spring-boot-starter/src/main/java/cn/dev33/satoken/spring/SaTokenInterceptorRegister.java
@@ -1,0 +1,19 @@
+package cn.dev33.satoken.spring;
+
+import cn.dev33.satoken.interceptor.SaInterceptor;
+import javax.annotation.Resource;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+public class SaTokenInterceptorRegister implements WebMvcConfigurer {
+
+  @Resource
+  private SaDynamicRouterExecutor saDynamicRouterExecutor;
+
+  @Override
+  public void addInterceptors(InterceptorRegistry registry) {
+    registry.addInterceptor(new SaInterceptor(r -> {
+      saDynamicRouterExecutor.execute();
+    }));
+  }
+}

--- a/sa-token-starter/sa-token-spring-boot3-starter/pom.xml
+++ b/sa-token-starter/sa-token-spring-boot3-starter/pom.xml
@@ -3,7 +3,7 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	
+
 	<parent>
         <groupId>cn.dev33</groupId>
         <artifactId>sa-token-starter</artifactId>
@@ -12,66 +12,66 @@
     </parent>
     <packaging>jar</packaging>
 
-	<name>sa-token-spring-boot3-starter</name>
-    <artifactId>sa-token-spring-boot3-starter</artifactId>
-	<description>springboot3 integrate sa-token</description>
+  <name>sa-token-spring-boot3-starter</name>
+  <artifactId>sa-token-spring-boot3-starter</artifactId>
+  <description>springboot3 integrate sa-token</description>
 
-    <properties>
-		<springboot3.version>3.0.1</springboot3.version>
-    </properties>
-    
-	<dependencies>
-		<!-- spring-boot-starter-web -->
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
-		
-		<!-- config (optional) -->
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-configuration-processor</artifactId>
-			<optional>true</optional>
-		</dependency>
-		
-		<!-- sa-token-jakarta-servlet -->
-		<dependency>
-			<groupId>cn.dev33</groupId>
-			<artifactId>sa-token-jakarta-servlet</artifactId>
-		</dependency>
-		
-		<!-- sa-token-spring-boot-autoconfig -->
-		<dependency>
-			<groupId>cn.dev33</groupId>
-			<artifactId>sa-token-spring-boot-autoconfig</artifactId>
-		</dependency>
-		
-	</dependencies>
+  <properties>
+    <springboot3.version>3.0.1</springboot3.version>
+  </properties>
 
-    <dependencyManagement>
-        <dependencies>
-			
-			<!-- spring-boot-starter -->
-	        <dependency>
-	            <groupId>org.springframework.boot</groupId>
-	            <artifactId>spring-boot-starter</artifactId>
-				<version>${springboot3.version}</version>
-	        </dependency>
-			<!-- spring-boot-starter-web -->
-			<dependency>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-starter-web</artifactId>
-				<version>${springboot3.version}</version>
-			</dependency>
-			<!-- config (optional) -->
-			<dependency>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-configuration-processor</artifactId>
-				<version>${springboot3.version}</version>
-			</dependency>
-			
-        </dependencies>
-    </dependencyManagement>
+  <dependencies>
+    <!-- spring-boot-starter-web -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+
+    <!-- config (optional) -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <!-- sa-token-jakarta-servlet -->
+    <dependency>
+      <groupId>cn.dev33</groupId>
+      <artifactId>sa-token-jakarta-servlet</artifactId>
+    </dependency>
+
+    <!-- sa-token-spring-boot-autoconfig -->
+    <dependency>
+      <groupId>cn.dev33</groupId>
+      <artifactId>sa-token-spring-boot-autoconfig</artifactId>
+    </dependency>
+
+  </dependencies>
+
+  <dependencyManagement>
+    <dependencies>
+
+      <!-- spring-boot-starter -->
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter</artifactId>
+        <version>${springboot3.version}</version>
+      </dependency>
+      <!-- spring-boot-starter-web -->
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-web</artifactId>
+        <version>${springboot3.version}</version>
+      </dependency>
+      <!-- config (optional) -->
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-configuration-processor</artifactId>
+        <version>${springboot3.version}</version>
+      </dependency>
+
+    </dependencies>
+  </dependencyManagement>
 
 
 </project>

--- a/sa-token-starter/sa-token-spring-boot3-starter/src/main/java/cn/dev33/satoken/spring/SaTokenInterceptorRegister.java
+++ b/sa-token-starter/sa-token-spring-boot3-starter/src/main/java/cn/dev33/satoken/spring/SaTokenInterceptorRegister.java
@@ -1,0 +1,19 @@
+package cn.dev33.satoken.spring;
+
+import cn.dev33.satoken.interceptor.SaInterceptor;
+import jakarta.annotation.Resource;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+public class SaTokenInterceptorRegister implements WebMvcConfigurer {
+
+  @Resource
+  private SaDynamicRouterExecutor saDynamicRouterExecutor;
+
+  @Override
+  public void addInterceptors(InterceptorRegistry registry) {
+    registry.addInterceptor(new SaInterceptor(r -> {
+      saDynamicRouterExecutor.execute();
+    }));
+  }
+}

--- a/sa-token-starter/sa-token-spring-boot3-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/sa-token-starter/sa-token-spring-boot3-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,2 @@
 cn.dev33.satoken.spring.SaTokenContextRegister
+cn.dev33.satoken.spring.SaTokenInterceptorRegister

--- a/sa-token-starter/sa-token-spring-cloud-config-starter/pom.xml
+++ b/sa-token-starter/sa-token-spring-cloud-config-starter/pom.xml
@@ -12,22 +12,16 @@
   </parent>
   <packaging>jar</packaging>
 
-  <name>sa-token-spring-boot-autoconfig</name>
-  <artifactId>sa-token-spring-boot-autoconfig</artifactId>
-  <description>sa-token-spring-boot-autoconfig</description>
+  <name>sa-token-spring-cloud-config-starter</name>
+  <artifactId>sa-token-spring-cloud-config-starter</artifactId>
+  <description>springcloud integrate sa-token</description>
 
   <dependencies>
 
-    <!-- spring-boot-starter (optional) -->
+    <!-- spring-boot-starter-web -->
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter</artifactId>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <optional>true</optional>
+      <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
 
     <!-- config (optional) -->
@@ -37,18 +31,27 @@
       <optional>true</optional>
     </dependency>
 
-    <!-- OAuth2.0 (optional) -->
+    <!-- sa-token-spring-boot-autoconfig -->
     <dependency>
       <groupId>cn.dev33</groupId>
-      <artifactId>sa-token-oauth2</artifactId>
-      <optional>true</optional>
+      <artifactId>sa-token-spring-boot-autoconfig</artifactId>
     </dependency>
 
-    <!-- SSO (optional) -->
+    <!--     https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-starter-config-->
     <dependency>
-      <groupId>cn.dev33</groupId>
-      <artifactId>sa-token-sso</artifactId>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-context</artifactId>
+      <version>2.2.8.RELEASE</version>
       <optional>true</optional>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-webmvc</artifactId>
+      <version>5.3.27</version>
+      <optional>true</optional>
+      <scope>provided</scope>
     </dependency>
 
   </dependencies>

--- a/sa-token-starter/sa-token-spring-cloud-config-starter/src/main/java/cn/dev33/satoken/spring/SaDynamicRouterRefreshConfig.java
+++ b/sa-token-starter/sa-token-spring-cloud-config-starter/src/main/java/cn/dev33/satoken/spring/SaDynamicRouterRefreshConfig.java
@@ -1,0 +1,34 @@
+package cn.dev33.satoken.spring;
+
+import cn.dev33.satoken.config.SaRouterConfig;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
+import org.springframework.stereotype.Component;
+
+
+/**
+ * 动态路由刷新配置
+ * <p>
+ * 使用 @RefreshScope 对 SaRouterConfig 进行动态配置，是的其成为Proxy类，方便后续使用注入
+ *
+ * @author einsitang
+ */
+@Component
+@RefreshScope
+public class SaDynamicRouterRefreshConfig {
+
+  /**
+   * SaRouterConfig
+   * <p>
+   * 被 @RefreshScope 包装后由原来的"单例注入"变成"代理单例注入"
+   */
+  private final SaRouterConfig saRouterConfig;
+
+  public SaDynamicRouterRefreshConfig(SaRouterConfig saRouterConfig) {
+    this.saRouterConfig = saRouterConfig;
+  }
+
+  public SaRouterConfig getSaRouterConfig() {
+    return this.saRouterConfig;
+  }
+
+}

--- a/sa-token-starter/sa-token-spring-cloud-config-starter/src/main/java/cn/dev33/satoken/spring/SaDynamicRouterRefreshListener.java
+++ b/sa-token-starter/sa-token-spring-cloud-config-starter/src/main/java/cn/dev33/satoken/spring/SaDynamicRouterRefreshListener.java
@@ -1,0 +1,38 @@
+package cn.dev33.satoken.spring;
+
+import cn.dev33.satoken.config.SaRouterConfig;
+import org.springframework.cloud.context.environment.EnvironmentChangeEvent;
+import org.springframework.context.event.EventListener;
+
+/**
+ * 动态路由刷新监听器
+ * <p>
+ * 通过对 EnvironmentChangeEvent 事件进行监听，触发sa-token.router 则对动态路由执行器进行刷新/重置
+ *
+ * @author einsitang
+ */
+public class SaDynamicRouterRefreshListener {
+
+  public SaDynamicRouterRefreshListener(SaDynamicRouterRefreshConfig saDynamicRouterRefreshInject,
+      SaDynamicRouterExecutor saDynamicRouterExecutor) {
+    this.saDynamicRouterRefreshInject = saDynamicRouterRefreshInject;
+    this.saDynamicRouterExecutor = saDynamicRouterExecutor;
+  }
+
+  private final SaDynamicRouterRefreshConfig saDynamicRouterRefreshInject;
+
+  private final SaDynamicRouterExecutor saDynamicRouterExecutor;
+
+  @EventListener(EnvironmentChangeEvent.class)
+  public void onRefresh(EnvironmentChangeEvent event) {
+    for (String key : event.getKeys()) {
+      if (key.startsWith("sa-token.router")) {
+
+        SaRouterConfig config = saDynamicRouterRefreshInject.getSaRouterConfig();
+        saDynamicRouterExecutor.reset(config.getEnable(), config.getRules());
+        break;
+      }
+    }
+  }
+
+}

--- a/sa-token-starter/sa-token-spring-cloud-config-starter/src/main/java/cn/dev33/satoken/spring/annotation/EnableRefreshDynamicRouter.java
+++ b/sa-token-starter/sa-token-spring-cloud-config-starter/src/main/java/cn/dev33/satoken/spring/annotation/EnableRefreshDynamicRouter.java
@@ -1,0 +1,27 @@
+package cn.dev33.satoken.spring.annotation;
+
+import cn.dev33.satoken.spring.SaDynamicRouterRefreshConfig;
+import cn.dev33.satoken.spring.SaDynamicRouterRefreshListener;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.context.annotation.Import;
+
+/**
+ * 开启动态路由注解
+ * <p>
+ * 配合 配置服务 将可以实现动态路由刷新
+ * <p>
+ * 仅需要在SpringBoot/Cloud 项目启动时加入 @EnableRefreshDynamicRouter
+ *
+ * @author einsitang
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Import({SaDynamicRouterRefreshListener.class, SaDynamicRouterRefreshConfig.class})
+public @interface EnableRefreshDynamicRouter {
+
+}


### PR DESCRIPTION
**配置路由**

该方式是通过配置的形式替代编写路由拦截器(`SpringBoot`/`SpringBoot3`)

```yaml
sa-token:
  router:
   # enable = true 开启
    enable: true
    rules:
      - match: [ "/a/**","/b/**" ]
        notMatch:
          - "/a/login"
        matchMethod:
          - "POST"
        notMatchMethod:
          - "GET"
          - "HEAD"
        check:
          # StpUtil.checkRoleAnd ...
          roles: [ "a","b" ]
          # StpUtil.checkRoleOr ...
          rolesOr: ["d","e"]
          # StpUtil.checkPermissionAnd ...
          permissions: ["p1","p2"]
          # StpUtil.checkPermissionOr ...
          permissionsOr: ["p3","p4"]
          # 默认true, true 执行 StpUtil.checkLogin() 
          loginRequired: true
      - match: ["/admin/**"]
      	check:
          roles: ["admin"]
      - ...
```

**动态路由**
配合 `SpringCloud` 的配置中心 如:`nacos` 实现**配置路由**的热更新

额外加上maven依赖
```
    <dependency>
      <groupId>cn.dev33</groupId>
      <artifactId>sa-token-spring-cloud-config-starter</artifactId>
      <version>${VERSION}</version>
    </dependency>
```
在应用内加上注解 `@EnableRefreshDynamicRouter` 即可随时在配置中心上实行配置路由的热更新

