### PR TITLE
StpInterface接口提供泛型指参

### DIFF
--- a/sa-token-core/src/main/java/cn/dev33/satoken/stp/StpInterface.java
+++ b/sa-token-core/src/main/java/cn/dev33/satoken/stp/StpInterface.java
@@ -28,7 +28,7 @@ import java.util.List;
  * @author click33
  * @since 1.10.0
  */
-public interface StpInterface {
+public interface StpInterface<T> {
 
 	/**
 	 * 返回指定账号id所拥有的权限码集合 
@@ -37,7 +37,7 @@ public interface StpInterface {
 	 * @param loginType 账号类型
 	 * @return 该账号id具有的权限码集合
 	 */
-	List<String> getPermissionList(Object loginId, String loginType);
+	List<String> getPermissionList(T loginId, String loginType);
 
 	/**
 	 * 返回指定账号id所拥有的角色标识集合 
@@ -46,6 +46,6 @@ public interface StpInterface {
 	 * @param loginType 账号类型
 	 * @return 该账号id具有的角色标识集合
 	 */
-	List<String> getRoleList(Object loginId, String loginType);
+	List<String> getRoleList(T loginId, String loginType);
 
 }

--- a/sa-token-core/src/main/java/cn/dev33/satoken/stp/StpInterfaceDefaultImpl.java
+++ b/sa-token-core/src/main/java/cn/dev33/satoken/stp/StpInterfaceDefaultImpl.java
@@ -26,7 +26,7 @@ import java.util.List;
  * @author click33
  * @since 1.10.0
  */
-public class StpInterfaceDefaultImpl implements StpInterface {
+public class StpInterfaceDefaultImpl implements StpInterface<Object> {
 
 	@Override
 	public List<String> getPermissionList(Object loginId, String loginType) {


### PR DESCRIPTION
主要针对几个项目中涉及StpInterface的以下两个问题：
1、某些方法的入参是 method(Serializable id)，需要强转
2、权限链路长，以及涉及人员多时，一定需要第一个开发者将id的类型指定；
很简单的改动，虽然都只需要一行代码可以解决问题，但是更希望应用框架的方法所见即所得，不在方法内部做这个事
