### PR TITLE
集成thymeleaf插件移除渲染后的<html>标签的命名空间

### DIFF
--- a/sa-token-plugin/sa-token-dialect-thymeleaf/src/main/java/cn/dev33/satoken/thymeleaf/dialect/SaTokenDialect.java
+++ b/sa-token-plugin/sa-token-dialect-thymeleaf/src/main/java/cn/dev33/satoken/thymeleaf/dialect/SaTokenDialect.java
@@ -26,6 +26,8 @@ import org.thymeleaf.processor.IProcessor;
 import cn.dev33.satoken.stp.StpLogic;
 import cn.dev33.satoken.stp.StpUtil;
 import cn.dev33.satoken.util.SaFoxUtil;
+import org.thymeleaf.standard.processor.StandardXmlNsTagProcessor;
+import org.thymeleaf.templatemode.TemplateMode;
 
 /**
  * Sa-Token 集成 Thymeleaf 标签方言 
@@ -82,7 +84,10 @@ public class SaTokenDialect extends AbstractProcessorDialect {
 				new SaTokenTagProcessor(prefix, "hasPermissionAnd", value -> stpLogic.hasPermissionAnd(toArray(value))),
 				new SaTokenTagProcessor(prefix, "hasPermissionOr", value -> stpLogic.hasPermissionOr(toArray(value))),
 				new SaTokenTagProcessor(prefix, "notPermission", value -> ! stpLogic.hasPermission(value)),
-				new SaTokenTagProcessor(prefix, "lackPermission", value -> ! stpLogic.hasPermission(value))
+				new SaTokenTagProcessor(prefix, "lackPermission", value -> ! stpLogic.hasPermission(value)),
+
+				// 移除<html>标签命名空间
+				new StandardXmlNsTagProcessor(TemplateMode.HTML,prefix)
 
 		));
     }


### PR DESCRIPTION
在thymeleaf模板中加上命名空间之后，渲染后命名空间不会移除
\<html lang="zh" xmlns:sa="http://www.thymeleaf.org/extras/sa-token">   

目的：渲染后移除命名空间

   \<html lang="zh" >