### PR TITLE
Fix: Replace Unsafe Java Deserialization with Jackson Mapper

### DIFF
--- a/sa-token-starter/sa-token-jboot-plugin/src/main/java/cn/dev33/satoken/jboot/SaJdkSerializer.java
+++ b/sa-token-starter/sa-token-jboot-plugin/src/main/java/cn/dev33/satoken/jboot/SaJdkSerializer.java
@@ -55,18 +55,25 @@ public class SaJdkSerializer implements JbootSerializer {
         if (bytes == null || bytes.length == 0) {
             return null;
         }
-        ObjectInputStream objectInput = null;
+        
+        ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
         try {
-            ByteArrayInputStream bytesInput = new ByteArrayInputStream(bytes);
-            objectInput = new ObjectInputStream(bytesInput);
-            return objectInput.readObject();
-        }
-        catch (Exception e) {
+            // Configure mapper for safe deserialization
+            mapper.configure(MapperFeature.AUTO_DETECT_FIELDS, true);
+            mapper.configure(MapperFeature.AUTO_DETECT_SETTERS, true);
+            mapper.enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+            
+            // Use mapper instead of ObjectInputStream
+            return mapper.readValue(bais, _clazz);
+        } catch (Exception e) {
+            LOG.error("Error during deserialization of bytes", e);
             throw new RuntimeException(e);
-        }
-        finally {
-            if (objectInput != null)
-                try {objectInput.close();} catch (Exception e) {LOG.error(e.getMessage(), e);}
+        } finally {
+            try {
+                bais.close();
+            } catch (Exception e) {
+                LOG.error(e.getMessage(), e);
+            }
         }
     }
 }


### PR DESCRIPTION
This PR addresses a critical security vulnerability in the code that could lead to Remote Code Execution (RCE).

The code was using Java's built-in ObjectInputStream.readObject() for deserialization, which is known to be vulnerable to deserialization attacks if the input comes from an untrusted source.

This vulnerability was initially found and fixed in the git commit below.

**References:**
[https://github.com/apache/helix/commit/7af17a31819859e6c46bcb3994ef7d52347760c4](url)
