### PR TITLE
在@SaCheckOr中增加@SaCheckApiKey的校验

### DIFF
--- a/sa-token-core/src/main/java/cn/dev33/satoken/annotation/SaCheckOr.java
+++ b/sa-token-core/src/main/java/cn/dev33/satoken/annotation/SaCheckOr.java
@@ -81,4 +81,10 @@ public @interface SaCheckOr {
      */
     SaCheckDisable[] disable() default {};
 
+    /**
+     * 设定 @SaCheckApiKey，参考 {@link SaCheckApiKey}
+     *
+     * @return /
+     */
+    SaCheckApiKey[] apikey() default {};
 }

--- a/sa-token-core/src/main/java/cn/dev33/satoken/annotation/handler/SaCheckOrHandler.java
+++ b/sa-token-core/src/main/java/cn/dev33/satoken/annotation/handler/SaCheckOrHandler.java
@@ -40,7 +40,7 @@ public class SaCheckOrHandler implements SaAnnotationHandlerInterface<SaCheckOr>
 
     @Override
     public void checkMethod(SaCheckOr at, Method method) {
-        _checkMethod(at.login(), at.role(), at.permission(), at.safe(), at.httpBasic(), at.httpDigest(), at.disable(), method);
+        _checkMethod(at.login(), at.role(), at.permission(), at.safe(), at.httpBasic(), at.httpDigest(), at.disable(), at.apikey(), method);
     }
 
     public static void _checkMethod(
@@ -51,6 +51,7 @@ public class SaCheckOrHandler implements SaAnnotationHandlerInterface<SaCheckOr>
             SaCheckHttpBasic[] httpBasic,
             SaCheckHttpDigest[] httpDigest,
             SaCheckDisable[] disable,
+            SaCheckApiKey[] apikey,
             Method method
     ) {
         // 先把所有注解塞到一个 list 里
@@ -62,6 +63,7 @@ public class SaCheckOrHandler implements SaAnnotationHandlerInterface<SaCheckOr>
         annotationList.addAll(Arrays.asList(disable));
         annotationList.addAll(Arrays.asList(httpBasic));
         annotationList.addAll(Arrays.asList(httpDigest));
+        annotationList.addAll(Arrays.asList(apikey));
 
         // 如果 atList 为空，说明 SaCheckOr 上不包含任何注解校验，我们直接跳过即可
         if(annotationList.isEmpty()) {


### PR DESCRIPTION
feat(sa-token): 在 SaCheckOr 中集成 SaCheckApiKey 功能- 在 SaCheckOr 注解中添加 a…pikey() 方法，用于设定 @SaCheckApiKey 的或校验

- 在 SaCheckOrHandler 中实现对 apikey() 的处理逻辑
- 通过 _checkMethod 方法将 apikey 参数传递给底层校验逻辑