### PR TITLE
fix: Bearer 全局统一大小写。

### DIFF
--- a/sa-token-plugin/sa-token-oauth2/src/main/java/cn/dev33/satoken/oauth2/data/convert/SaOAuth2DataConverterDefaultImpl.java
+++ b/sa-token-plugin/sa-token-oauth2/src/main/java/cn/dev33/satoken/oauth2/data/convert/SaOAuth2DataConverterDefaultImpl.java
@@ -104,7 +104,7 @@ public class SaOAuth2DataConverterDefaultImpl implements SaOAuth2DataConverter, 
         at.clientId = ra.clientId;
         at.loginId = ra.loginId;
         at.scopes = ra.scopes;
-        at.tokenType = SaOAuth2Consts.TokenType.bearer;
+        at.tokenType = SaOAuth2Consts.TokenType.Bearer;
         at.expiresTime = ttlToExpireTime(accessTokenTimeout);
         at.extraData = new LinkedHashMap<>();
         return at;
@@ -120,7 +120,7 @@ public class SaOAuth2DataConverterDefaultImpl implements SaOAuth2DataConverter, 
         at.clientId = cm.clientId;
         at.loginId = cm.loginId;
         at.scopes = cm.scopes;
-        at.tokenType = SaOAuth2Consts.TokenType.bearer;
+        at.tokenType = SaOAuth2Consts.TokenType.Bearer;
         at.grantType = GrantType.authorization_code;
         at.expiresTime = ttlToExpireTime(accessTokenTimeout);
         at.extraData = new LinkedHashMap<>();
@@ -153,7 +153,7 @@ public class SaOAuth2DataConverterDefaultImpl implements SaOAuth2DataConverter, 
         at.clientId = rt.clientId;
         at.loginId = rt.loginId;
         at.scopes = rt.scopes;
-        at.tokenType = SaOAuth2Consts.TokenType.bearer;
+        at.tokenType = SaOAuth2Consts.TokenType.Bearer;
         at.grantType = GrantType.refresh_token;
         at.extraData = new LinkedHashMap<>(rt.extraData);
         at.expiresTime = ttlToExpireTime(accessTokenTimeout);
@@ -189,7 +189,7 @@ public class SaOAuth2DataConverterDefaultImpl implements SaOAuth2DataConverter, 
         ct.clientToken = clientTokenValue;
         ct.clientId = clientModel.getClientId();
         ct.scopes = scopes;
-        ct.tokenType = SaOAuth2Consts.TokenType.bearer;
+        ct.tokenType = SaOAuth2Consts.TokenType.Bearer;
         ct.expiresTime = ttlToExpireTime(clientModel.getClientTokenTimeout());
         ct.grantType = GrantType.client_credentials;
         ct.extraData = new LinkedHashMap<>();


### PR DESCRIPTION
读取token使用首字母大写的Bearer,这个是标准要求。
生成AccessTokenModel时候，tokenType也使用首字母大写，保持全局一致。

<img width="784" height="401" alt="0289ae07963eef9da4ba1ed9e66c4a77" src="https://github.com/user-attachments/assets/2e39d993-cb79-4375-91a4-e6712779c1f2" />

<img width="835" height="632" alt="9010608bd8a686299050b5dfae172bd4" src="https://github.com/user-attachments/assets/61b4b446-d7e6-4475-891e-cdca90573d45" />
