### PR TITLE
feat：新增@SaCheckLogin的checkParent功能

### DIFF
--- a/sa-token-core/src/main/java/cn/dev33/satoken/annotation/SaCheckLogin.java
+++ b/sa-token-core/src/main/java/cn/dev33/satoken/annotation/SaCheckLogin.java
@@ -39,4 +39,6 @@ public @interface SaCheckLogin {
      */
     String type() default "";
 
+    boolean checkParent() default false;
+
 }

--- a/sa-token-core/src/main/java/cn/dev33/satoken/context/SaHolder.java
+++ b/sa-token-core/src/main/java/cn/dev33/satoken/context/SaHolder.java
@@ -28,6 +28,27 @@ import cn.dev33.satoken.context.model.SaStorage;
  * @since 1.18.0
  */
 public class SaHolder {
+
+    /**
+     * 当前请求实际调用的 Controller 类 (用于父类方法继承子类注解)
+     */
+    private static final ThreadLocal<Class<?>> actualClassHolder = new ThreadLocal<>();
+
+    /**
+     * 设置当前请求实际调用的 Controller 类
+     * @param clazz 实际的 Controller 类
+     */
+    public static void setActualClass(Class<?> clazz) {
+        actualClassHolder.set(clazz);
+    }
+
+    /**
+     * 获取当前请求实际调用的 Controller 类
+     * @return 实际的 Controller 类
+     */
+    public static Class<?> getActualClass() {
+        return actualClassHolder.get();
+    }
 	
 	/**
 	 * 获取当前请求的 SaTokenContext 上下文对象

--- a/sa-token-core/src/main/java/cn/dev33/satoken/fun/SaCheckParentMethodAnnotationFunction.java
+++ b/sa-token-core/src/main/java/cn/dev33/satoken/fun/SaCheckParentMethodAnnotationFunction.java
@@ -1,0 +1,19 @@
+package cn.dev33.satoken.fun;
+
+import java.lang.reflect.Method;
+
+/**
+ * 函数式接口:检查父类方法的注解
+ * 
+ * @author ShiYi
+ */
+@FunctionalInterface
+public interface SaCheckParentMethodAnnotationFunction {
+
+    /**
+     * 检查父类方法的注解
+     * @param method 当前方法
+     */
+    void accept(Method method);
+    
+}

--- a/sa-token-core/src/main/java/cn/dev33/satoken/strategy/SaAnnotationStrategy.java
+++ b/sa-token-core/src/main/java/cn/dev33/satoken/strategy/SaAnnotationStrategy.java
@@ -17,6 +17,8 @@ package cn.dev33.satoken.strategy;
 
 import cn.dev33.satoken.annotation.*;
 import cn.dev33.satoken.annotation.handler.*;
+import cn.dev33.satoken.context.SaHolder;
+import cn.dev33.satoken.fun.SaCheckParentMethodAnnotationFunction;
 import cn.dev33.satoken.fun.strategy.*;
 import cn.dev33.satoken.listener.SaTokenEventCenter;
 import cn.dev33.satoken.router.SaRouter;
@@ -104,9 +106,63 @@ public final class SaAnnotationStrategy {
 
 		// 再校验 Method 上的注解
 		instance.checkElementAnnotation.accept(method);
+
+        // 实现 SaCheckLogin 子类注解的 checkParent 功能
+        instance.checkParentMethodAnnotation.accept(method);
 	};
 
-	/**
+    public SaCheckParentMethodAnnotationFunction checkParentMethodAnnotation = (method) -> {
+        //检查父类方法本身有没有鉴权注解
+        if (hasAuthAnnotation(method)) {
+            return; // 如果父类方法有注解,优先使用方法自己的注解
+        }
+        //获取方法所属类(父类)
+        Class<?> declaringClass = method.getDeclaringClass();
+
+        // 检查父类(方法所属类)有没有 @SaCheckLogin(checkParent=true)
+        SaCheckLogin declaringClassCheckLogin = (SaCheckLogin) instance.getAnnotation.apply(
+                declaringClass,
+                SaCheckLogin.class
+        );
+        if (declaringClassCheckLogin != null && declaringClassCheckLogin.checkParent()) {
+            return;
+        }
+
+        //获取实际调用的类(子类)
+        Class<?> actualClass = SaHolder.getActualClass();
+        if (actualClass == null || actualClass.equals(declaringClass)) {
+            return; // 无法获取实际类,或者不是继承场景
+        }
+        // 检查子类有没有 @SaCheckLogin(checkParent=true)
+        SaCheckLogin actualClassCheckLogin = (SaCheckLogin) instance.getAnnotation.apply(
+                actualClass,
+                SaCheckLogin.class
+        );
+        //用子类的注解校验父类方法
+        if (actualClassCheckLogin != null && actualClassCheckLogin.checkParent()) {
+            SaCheckLoginHandler handler = new SaCheckLoginHandler();
+            handler.check(actualClassCheckLogin, method);
+        }
+    };
+
+
+
+    /**
+     * 判断方法上是否有鉴权注解
+     */
+    private boolean hasAuthAnnotation(java.lang.reflect.Method method) {
+        for (Class<?> annotationClass : annotationHandlerMap.keySet()) {
+            if (instance.getAnnotation.apply(method, (Class<Annotation>) annotationClass) != null) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+
+
+    /**
 	 * 对一个 [Element] 对象进行注解校验 （注解鉴权内部实现）
 	 */
 	@SuppressWarnings("unchecked")

--- a/sa-token-starter/sa-token-spring-boot-starter/src/main/java/cn/dev33/satoken/interceptor/SaInterceptor.java
+++ b/sa-token-starter/sa-token-spring-boot-starter/src/main/java/cn/dev33/satoken/interceptor/SaInterceptor.java
@@ -15,6 +15,7 @@
  */
 package cn.dev33.satoken.interceptor;
 
+import cn.dev33.satoken.context.SaHolder;
 import cn.dev33.satoken.exception.BackResultException;
 import cn.dev33.satoken.exception.StopMatchException;
 import cn.dev33.satoken.fun.SaParamFunction;
@@ -110,6 +111,10 @@ public class SaInterceptor implements HandlerInterceptor {
 			// 前置函数：在注解鉴权之前执行
 			beforeAuth.run(handler);
 
+            if (handler instanceof HandlerMethod) {
+                SaHolder.setActualClass(((HandlerMethod) handler).getBeanType());
+            }
+
 			// 这里必须确保 handler 是 HandlerMethod 类型时，才能进行注解鉴权
 			if(isAnnotation && handler instanceof HandlerMethod) {
 				Method method = ((HandlerMethod) handler).getMethod();
@@ -131,7 +136,9 @@ public class SaInterceptor implements HandlerInterceptor {
 			}
 			response.getWriter().print(e.getMessage());
 			return false;
-		}
+		}finally {
+            SaHolder.setActualClass(null);
+        }
 		
 		// 通过验证 
 		return true;

--- a/sa-token-starter/sa-token-spring-boot3-starter/src/main/java/cn/dev33/satoken/interceptor/SaInterceptor.java
+++ b/sa-token-starter/sa-token-spring-boot3-starter/src/main/java/cn/dev33/satoken/interceptor/SaInterceptor.java
@@ -15,6 +15,7 @@
  */
 package cn.dev33.satoken.interceptor;
 
+import cn.dev33.satoken.context.SaHolder;
 import cn.dev33.satoken.exception.BackResultException;
 import cn.dev33.satoken.exception.StopMatchException;
 import cn.dev33.satoken.fun.SaParamFunction;
@@ -92,6 +93,10 @@ public class SaInterceptor implements HandlerInterceptor {
 		
 		try {
 
+            if (handler instanceof HandlerMethod) {
+                SaHolder.setActualClass(((HandlerMethod) handler).getBeanType());
+            }
+
 			// 这里必须确保 handler 是 HandlerMethod 类型时，才能进行注解鉴权
 			if(isAnnotation && handler instanceof HandlerMethod) {
 				Method method = ((HandlerMethod) handler).getMethod();
@@ -113,7 +118,9 @@ public class SaInterceptor implements HandlerInterceptor {
 			}
 			response.getWriter().print(e.getMessage());
 			return false;
-		}
+		}finally {
+            SaHolder.setActualClass(null);
+        }
 		
 		// 通过验证 
 		return true;


### PR DESCRIPTION
适用场景：当父类controller没有@SaCheckLogin，如果请求的继承父类的子类controller存在@SaCheckLogin(checkParent=true)，则会用子类的@SaCheckLogin去校验父类