### PR TITLE
refactor: SaTokenDubboContextFilter 改为使用 SaTokenContextDubboUtil 清理上下文

### DIFF
--- a/sa-token-plugin/sa-token-dubbo/src/main/java/cn/dev33/satoken/context/dubbo/filter/SaTokenDubboContextFilter.java
+++ b/sa-token-plugin/sa-token-dubbo/src/main/java/cn/dev33/satoken/context/dubbo/filter/SaTokenDubboContextFilter.java
@@ -15,7 +15,6 @@
  */
 package cn.dev33.satoken.context.dubbo.filter;
 
-import cn.dev33.satoken.SaManager;
 import cn.dev33.satoken.context.SaHolder;
 import cn.dev33.satoken.context.dubbo.util.SaTokenContextDubboUtil;
 import cn.dev33.satoken.util.SaTokenConsts;
@@ -41,7 +40,7 @@ public class SaTokenDubboContextFilter implements Filter {
 			SaTokenContextDubboUtil.setContext(RpcContext.getContext());
 			return invoker.invoke(invocation);
 		} finally {
-			SaManager.getSaTokenContext().clearContext();
+			SaTokenContextDubboUtil.clearContext();
 		}
 	}
 

--- a/sa-token-plugin/sa-token-dubbo3/src/main/java/cn/dev33/satoken/context/dubbo3/filter/SaTokenDubbo3ContextFilter.java
+++ b/sa-token-plugin/sa-token-dubbo3/src/main/java/cn/dev33/satoken/context/dubbo3/filter/SaTokenDubbo3ContextFilter.java
@@ -15,7 +15,6 @@
  */
 package cn.dev33.satoken.context.dubbo3.filter;
 
-import cn.dev33.satoken.SaManager;
 import cn.dev33.satoken.context.SaHolder;
 import cn.dev33.satoken.context.dubbo3.util.SaTokenContextDubbo3Util;
 import cn.dev33.satoken.util.SaTokenConsts;
@@ -41,7 +40,7 @@ public class SaTokenDubbo3ContextFilter implements Filter {
 			SaTokenContextDubbo3Util.setContext(RpcContext.getServiceContext());
 			return invoker.invoke(invocation);
 		} finally {
-			SaManager.getSaTokenContext().clearContext();
+			SaTokenContextDubbo3Util.clearContext();
 		}
 
 	}


### PR DESCRIPTION
SaTokenDubboContextFilter 在写入时使用了 SaTokenContextDubboUtil.setContext()，但在清除时却直接调用了底层的 SaManager.getSaTokenContext().clearContext()。修复后改为统一调用 SaTokenContextDubboUtil.clearContext()。