### PR TITLE
feat(dubbo): 添加 RPC 调用 Same-Token 校验忽略功能

### DIFF
--- a/sa-token-core/src/main/java/cn/dev33/satoken/config/SaTokenConfig.java
+++ b/sa-token-core/src/main/java/cn/dev33/satoken/config/SaTokenConfig.java
@@ -21,6 +21,8 @@ import cn.dev33.satoken.stp.parameter.enums.SaReplacedRange;
 import cn.dev33.satoken.util.SaFoxUtil;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Sa-Token 配置类 Model
@@ -215,6 +217,9 @@ public class SaTokenConfig implements Serializable {
 	 * 是否校验 Same-Token（部分rpc插件有效）
 	 */
 	private Boolean checkSameToken = false;
+
+    // 忽略
+    private List<String> ignoreSameTokenPaths = new ArrayList<>();
 
 	/**
 	 * Cookie配置对象 
@@ -941,4 +946,11 @@ public class SaTokenConfig implements Serializable {
 		return this;
 	}
 
+    public List<String> getIgnoreSameTokenPaths() {
+        return ignoreSameTokenPaths;
+    }
+
+    public void setIgnoreSameTokenPaths(List<String> ignoreSameTokenPaths) {
+        this.ignoreSameTokenPaths = ignoreSameTokenPaths;
+    }
 }

--- a/sa-token-plugin/sa-token-dubbo3/src/main/java/cn/dev33/satoken/context/dubbo3/filter/SaTokenDubbo3ProviderFilter.java
+++ b/sa-token-plugin/sa-token-dubbo3/src/main/java/cn/dev33/satoken/context/dubbo3/filter/SaTokenDubbo3ProviderFilter.java
@@ -16,7 +16,9 @@
 package cn.dev33.satoken.context.dubbo3.filter;
 
 import cn.dev33.satoken.SaManager;
+import cn.dev33.satoken.config.SaTokenConfig;
 import cn.dev33.satoken.same.SaSameUtil;
+import cn.dev33.satoken.stp.StpUtil;
 import cn.dev33.satoken.util.SaTokenConsts;
 import org.apache.dubbo.common.constants.CommonConstants;
 import org.apache.dubbo.common.extension.Activate;
@@ -24,6 +26,9 @@ import org.apache.dubbo.rpc.Filter;
 import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
 import org.apache.dubbo.rpc.Result;
+import org.apache.dubbo.rpc.RpcContext;
+
+import java.util.List;
 
 /**
  * Sa-Token 整合 Dubbo3 Provider端（被调用端）过滤器
@@ -34,21 +39,30 @@ import org.apache.dubbo.rpc.Result;
 @Activate(group = {CommonConstants.PROVIDER}, order = SaTokenConsts.RPC_PERMISSION_FILTER_ORDER)
 public class SaTokenDubbo3ProviderFilter implements Filter {
 
-	@Override
-	public Result invoke(Invoker<?> invoker, Invocation invocation) {
-		
-		// RPC 调用鉴权 
-		if(SaManager.getConfig().getCheckSameToken()) {
-			String idToken = invocation.getAttachment(SaSameUtil.SAME_TOKEN);
-			// dubbo部分协议会将参数变为小写，详细参考：https://gitee.com/dromara/sa-token/issues/I4WXQG
-			if(idToken == null) {
-				idToken = invocation.getAttachment(SaSameUtil.SAME_TOKEN.toLowerCase());
-			}
-			SaSameUtil.checkToken(idToken);
-		}
-		
-		// 开始调用
-		return invoker.invoke(invocation);
-	}
+    @Override
+    public Result invoke(Invoker<?> invoker, Invocation invocation) {
+
+        // 新加白名单能力，对指定的 RPC 调用不进行 Same-Token 校验
+        List<String> ignoreSameTokenPaths = SaManager.getConfig().getIgnoreSameTokenPaths();
+        String interfaceName = invoker.getInterface().getName();
+        String methodName = invocation.getMethodName();
+        String rpcKey = interfaceName + ":" + methodName + ":*:*";
+        if (ignoreSameTokenPaths.contains(rpcKey)) {
+            return invoker.invoke(invocation);
+        }
+
+        // RPC 调用鉴权
+        if (SaManager.getConfig().getCheckSameToken()) {
+            String idToken = invocation.getAttachment(SaSameUtil.SAME_TOKEN);
+            // dubbo部分协议会将参数变为小写，详细参考：https://gitee.com/dromara/sa-token/issues/I4WXQG
+            if (idToken == null) {
+                idToken = invocation.getAttachment(SaSameUtil.SAME_TOKEN.toLowerCase());
+            }
+            SaSameUtil.checkToken(idToken);
+        }
+
+        // 开始调用
+        return invoker.invoke(invocation);
+    }
 
 }


### PR DESCRIPTION
- 在 SaTokenConfig 中新增 ignoreSameTokenPaths 配置项

场景：在 websocket 链接链路中，onConnect 未透传token 。同时又开启了checkSameToken=true。在onConnect 跟onDisconnect 方法里面调用 dubbo 方法更新用户上下线存在校验 sameToken 场景。


