### PR TITLE
refactor: add final modifier to URL_REGEX constant in SaFoxUtil

### DIFF
--- a/sa-token-core/src/main/java/cn/dev33/satoken/util/SaFoxUtil.java
+++ b/sa-token-core/src/main/java/cn/dev33/satoken/util/SaFoxUtil.java
@@ -559,7 +559,7 @@ public class SaFoxUtil {
 	/**
 	 * 验证URL的正则表达式
 	 */
-	public static String URL_REGEX = "(https?|ftp|file)://[-A-Za-z0-9+&@#/%?=~_|!:,.;]+[-A-Za-z0-9+&@#/%=~_|]";
+	public static final String URL_REGEX = "(https?|ftp|file)://[-A-Za-z0-9+&@#/%?=~_|!:,.;]+[-A-Za-z0-9+&@#/%=~_|]";
 
 	/**
 	 * 使用正则表达式判断一个字符串是否为URL


### PR DESCRIPTION
## Problem

`SaFoxUtil.URL_REGEX` is declared as a public static field without the `final` modifier, which means it can be accidentally (or maliciously) reassigned at runtime, potentially breaking URL validation logic across the entire application.

## Fix

Added the `final` modifier to ensure the constant is truly immutable.

## Change

`sa-token-core/src/main/java/cn/dev33/satoken/util/SaFoxUtil.java`

`diff
- public static String URL_REGEX = "(https?|ftp|file)://...";
+ public static final String URL_REGEX = "(https?|ftp|file)://...";
`

## Impact

- Zero behavior change ??purely a defensive code quality improvement
- Prevents accidental mutation of a security-sensitive regex constant