### PR TITLE
fix: specify StandardCharsets.UTF_8 in md5() to ensure cross-platform consistency

### DIFF
--- a/sa-token-core/src/main/java/cn/dev33/satoken/secure/SaSecureUtil.java
+++ b/sa-token-core/src/main/java/cn/dev33/satoken/secure/SaSecureUtil.java
@@ -65,7 +65,7 @@ public class SaSecureUtil {
 		str = (str == null ? "" : str);
 		char[] hexDigits = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
 		try {
-			byte[] btInput = str.getBytes();
+			byte[] btInput = str.getBytes(StandardCharsets.UTF_8);
 			MessageDigest mdInst = MessageDigest.getInstance("MD5");
 			mdInst.update(btInput);
 			byte[] md = mdInst.digest();


### PR DESCRIPTION
## Problem

In `SaSecureUtil.md5()`, `str.getBytes()` is called without specifying a charset. This relies on the JVM default charset (`Charset.defaultCharset()`), which varies by platform and locale ??for example it may be `GBK` on Chinese Windows, `UTF-8` on Linux. As a result, the same input string can produce **different MD5 hashes on different platforms**, which breaks authentication and signature verification in cross-platform deployments.

## Fix

Explicitly pass `StandardCharsets.UTF_8` to `getBytes()` to guarantee consistent behavior regardless of JVM locale.

## Change

`sa-token-core/src/main/java/cn/dev33/satoken/secure/SaSecureUtil.java`

`diff
- byte[] btInput = str.getBytes();
+ byte[] btInput = str.getBytes(StandardCharsets.UTF_8);
`

## Notes

- `StandardCharsets` is already imported in the class ??no new dependency introduced
- `StandardCharsets.UTF_8` does not throw `UnsupportedEncodingException`, so the checked exception handling is also simplified