### PR TITLE
fix: resolve #902 — 对ApiKey的原子性的一些建议

### DIFF
--- a/sa-token-core/src/main/java/cn/dev33/satoken/annotation/handler/SaCheckApiKeyHandler.java
+++ b/sa-token-core/src/main/java/cn/dev33/satoken/annotation/handler/SaCheckApiKeyHandler.java
@@ -1,0 +1,37 @@
+package cn.dev33.satoken.annotation.handler;
+
+import cn.dev33.satoken.annotation.SaCheckApiKey;
+import cn.dev33.satoken.apikey.SaApiKeyUtil;
+import cn.dev33.satoken.apikey.model.ApiKeyModel;
+import cn.dev33.satoken.context.SaHolder;
+import cn.dev33.satoken.exception.ApiKeyException;
+
+import java.lang.reflect.Method;
+
+/**
+ * 注解 SaCheckApiKey 的处理器
+ *
+ * @author click33
+ */
+public class SaCheckApiKeyHandler implements SaAnnotationHandlerInterface<SaCheckApiKey> {
+
+	@Override
+	public Class<SaCheckApiKey> getHandlerAnnotationClass() {
+		return SaCheckApiKey.class;
+	}
+
+	@Override
+	public void checkMethod(SaCheckApiKey at, Method method) {
+		_checkMethod(at.value());
+	}
+
+	public static void _checkMethod(String... scopes) {
+		String apiKey = SaApiKeyUtil.readApiKeyValue(SaHolder.getRequest());
+		ApiKeyModel apiKeyModel = SaApiKeyUtil.getApiKey(apiKey);
+		if (apiKeyModel == null) {
+			throw new ApiKeyException("无效的 API Key:" + apiKey);
+		}
+		SaApiKeyUtil.checkApiKeyScope(apiKeyModel, scopes);
+	}
+
+}

--- a/sa-token-core/src/main/java/cn/dev33/satoken/apikey/SaApiKeyUtil.java
+++ b/sa-token-core/src/main/java/cn/dev33/satoken/apikey/SaApiKeyUtil.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2020-2099 sa-token.cc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cn.dev33.satoken.apikey;
+
+import cn.dev33.satoken.apikey.model.ApiKeyModel;
+import cn.dev33.satoken.apikey.template.SaApiKeyTemplate;
+
+import java.util.List;
+
+/**
+ * Sa-Token API Key 工具类
+ *
+ * @author click33
+ * @since 1.41.0
+ */
+public class SaApiKeyUtil {
+
+	private SaApiKeyUtil() {
+	}
+
+	/**
+	 * 底层使用的 API Key 操作模板对象
+	 */
+	public static SaApiKeyTemplate apiKeyTemplate = new SaApiKeyTemplate();
+
+	/**
+	 * 校验 ApiKey, 返回其代表的 LoginId, 如果校验失败则抛出异常
+	 *
+	 * @param apiKey /
+	 * @return /
+	 */
+	public static Object checkApiKey(String apiKey) {
+		return apiKeyTemplate.checkApiKey(apiKey);
+	}
+
+	/**
+	 * 校验 ApiKey 是否具有指定 Scope, 如果校验失败则抛出异常
+	 *
+	 * @param apiKey /
+	 * @param scopes /
+	 */
+	public static void checkApiKeyScope(String apiKey, String... scopes) {
+		apiKeyTemplate.checkApiKeyScope(apiKey, scopes);
+	}
+
+	/**
+	 * 校验 ApiKey 是否具有指定 Scope (指定多个,只要具有其中一个就通过校验), 如果校验失败则抛出异常
+	 *
+	 * @param apiKey /
+	 * @param scopes /
+	 */
+	public static void checkApiKeyScopeOr(String apiKey, String... scopes) {
+		apiKeyTemplate.checkApiKeyScopeOr(apiKey, scopes);
+	}
+
+	/**
+	 * 判断一个 ApiKey 是否有效
+	 *
+	 * @param apiKey /
+	 * @return /
+	 */
+	public static boolean isValid(String apiKey) {
+		return apiKeyTemplate.isValid(apiKey);
+	}
+
+	/**
+	 * 判断一个 ApiKey 是否拥有指定 Scope
+	 *
+	 * @param apiKey /
+	 * @param scope /
+	 * @return /
+	 */
+	public static boolean hasApiKeyScope(String apiKey, String scope) {
+		return apiKeyTemplate.hasApiKeyScope(apiKey, scope);
+	}
+
+	/**
+	 * 获取一个 ApiKey 的 Scope 列表
+	 *
+	 * @param apiKey /
+	 * @return /
+	 */
+	public static List<String> getApiKeyScopeList(String apiKey) {
+		return apiKeyTemplate.getApiKeyScopeList(apiKey);
+	}
+
+	/**
+	 * 获取 ApiKey 信息, 如果 ApiKey 无效则返回 null
+	 *
+	 * @param apiKey /
+	 * @return /
+	 */
+	public static ApiKeyModel getApiKey(String apiKey) {
+		return apiKeyTemplate.getApiKey(apiKey);
+	}
+
+	/**
+	 * 获取 ApiKey 信息, 如果 ApiKey 无效则返回 null
+	 *
+	 * @param apiKey /
+	 * @param noCache 是否绕过缓存,直接从数据加载器读取
+	 * @return /
+	 */
+	public static ApiKeyModel getApiKey(String apiKey, boolean noCache) {
+		return apiKeyTemplate.getApiKey(apiKey, noCache);
+	}
+
+	/**
+	 * 直接从数据加载器获取 ApiKey 信息(不走缓存), 如果 ApiKey 无效则返回 null
+	 *
+	 * @param apiKey /
+	 * @return /
+	 */
+	public static ApiKeyModel getApiKeyFromDataLoader(String apiKey) {
+		return apiKeyTemplate.getApiKeyFromDataLoader(apiKey);
+	}
+
+	/**
+	 * 创建一个 ApiKey (只是返回模型,不会保存到数据源中)
+	 *
+	 * @param loginId /
+	 * @return /
+	 */
+	public static ApiKeyModel createApiKeyModel(Object loginId) {
+		return apiKeyTemplate.createApiKeyModel(loginId);
+	}
+
+	/**
+	 * 保存一个 ApiKey 到数据源
+	 *
+	 * @param apiKeyModel /
+	 */
+	public static void saveApiKey(ApiKeyModel apiKeyModel) {
+		apiKeyTemplate.saveApiKey(apiKeyModel);
+	}
+
+	/**
+	 * 修改一个 ApiKey 的信息
+	 *
+	 * @param apiKeyModel /
+	 */
+	public static void editApiKey(ApiKeyModel apiKeyModel) {
+		apiKeyTemplate.editApiKey(apiKeyModel);
+	}
+
+	/**
+	 * 删除一个 ApiKey
+	 *
+	 * @param apiKey /
+	 */
+	public static void deleteApiKey(String apiKey) {
+		apiKeyTemplate.deleteApiKey(apiKey);
+	}
+
+	/**
+	 * 调整 ApiKey 的剩余有效时间, 单位:秒
+	 *
+	 * @param apiKey /
+	 * @param expiresTime 单位:秒, -1 代表永久有效
+	 */
+	public static void adjustApiKeyExpireTime(String apiKey, long expiresTime) {
+		apiKeyTemplate.adjustApiKeyExpireTime(apiKey, expiresTime);
+	}
+
+	/**
+	 * 获取指定账号的 ApiKey 列表记录
+	 *
+	 * @param loginId /
+	 * @return /
+	 */
+	public static List<ApiKeyModel> getApiKeyList(Object loginId) {
+		return apiKeyTemplate.getApiKeyList(loginId);
+	}
+
+	/**
+	 * 删除指定账号下的所有 ApiKey
+	 *
+	 * @param loginId /
+	 */
+	public static void deleteApiKeyByLoginId(Object loginId) {
+		apiKeyTemplate.deleteApiKeyByLoginId(loginId);
+	}
+
+}

--- a/sa-token-core/src/main/java/cn/dev33/satoken/apikey/loader/SaApiKeyDataLoader.java
+++ b/sa-token-core/src/main/java/cn/dev33/satoken/apikey/loader/SaApiKeyDataLoader.java
@@ -1,0 +1,34 @@
+package cn.dev33.satoken.apikey.loader;
+
+import cn.dev33.satoken.apikey.model.ApiKeyModel;
+
+/**
+ * Sa-Token ApiKey 数据加载器
+ *
+ * @author click33
+ * @since 1.41.0
+ */
+public interface SaApiKeyDataLoader {
+
+	/**
+	 * 根据 apiKey 从数据源加载 ApiKeyModel 信息
+	 *
+	 * @param apiKey /
+	 * @return /
+	 */
+	default ApiKeyModel getApiKeyModel(String apiKey) {
+		return null;
+	}
+
+	/**
+	 * 是否启用缓存模式：
+	 * <p> true：读取时优先从缓存中查找，未命中再从数据加载器加载（read-through，默认行为） </p>
+	 * <p> false：每次都从数据加载器中查找，缓存仅作为辅助 </p>
+	 *
+	 * @return /
+	 */
+	default boolean getIsCache() {
+		return true;
+	}
+
+}

--- a/sa-token-core/src/main/java/cn/dev33/satoken/apikey/template/SaApiKeyTemplate.java
+++ b/sa-token-core/src/main/java/cn/dev33/satoken/apikey/template/SaApiKeyTemplate.java
@@ -1,0 +1,131 @@
+package cn.dev33.satoken.apikey.template;
+
+import cn.dev33.satoken.SaManager;
+import cn.dev33.satoken.apikey.SaApiKeyManager;
+import cn.dev33.satoken.apikey.exception.ApiKeyException;
+import cn.dev33.satoken.apikey.loader.SaApiKeyDataLoader;
+import cn.dev33.satoken.apikey.model.ApiKeyModel;
+import cn.dev33.satoken.dao.SaTokenDao;
+import cn.dev33.satoken.error.SaErrorCode;
+import cn.dev33.satoken.secure.SaSecureUtil;
+import cn.dev33.satoken.util.SaFoxUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Sa-Token API Key 操作模板类
+ *
+ * @author click33
+ * @since 1.41.0
+ */
+public class SaApiKeyTemplate {
+
+	public static final String API_KEY_SAVE_KEY = "apikey:";
+	public static final String API_KEY_INDEX_SAVE_KEY = "apikey-index:";
+
+	public SaTokenDao getSaTokenDao() {
+		return SaManager.getSaTokenDao();
+	}
+
+	public String splicingApiKeySaveKey(String apiKey) {
+		return SaManager.getConfig().getTokenName() + ":" + API_KEY_SAVE_KEY + apiKey;
+	}
+
+	public String splicingApiKeyIndexSaveKey(Object loginId) {
+		return SaManager.getConfig().getTokenName() + ":" + API_KEY_INDEX_SAVE_KEY + loginId;
+	}
+
+	public ApiKeyModel createApiKeyModel(Object loginId) {
+		return SaApiKeyManager.getDataLoader().createApiKeyModel(loginId);
+	}
+
+	public ApiKeyModel getApiKey(String apiKey) {
+		return getApiKey(apiKey, !SaApiKeyManager.getDataLoader().getIsAlwaysFromDataLoader());
+	}
+
+	public ApiKeyModel getApiKey(String apiKey, boolean fromCache) {
+		if (SaFoxUtil.isEmpty(apiKey)) {
+			return null;
+		}
+
+		if (fromCache) {
+			ApiKeyModel akModel = (ApiKeyModel) getSaTokenDao().getObject(splicingApiKeySaveKey(apiKey));
+			if (akModel != null) {
+				return akModel;
+			}
+		}
+
+		SaApiKeyDataLoader dataLoader = SaApiKeyManager.getDataLoader();
+		ApiKeyModel akModel = dataLoader.getApiKeyFromDatabase(apiKey);
+		if (akModel == null) {
+			return null;
+		}
+
+		if (dataLoader.getIsCacheable(akModel)) {
+			saveApiKey(akModel);
+		}
+
+		return akModel;
+	}
+
+	public ApiKeyModel checkApiKey(String apiKey) {
+		ApiKeyModel akModel = getApiKey(apiKey);
+		if (akModel == null) {
+			throw new ApiKeyException("无效 API Key:" + apiKey).setCode(SaErrorCode.CODE_12301);
+		}
+		if (!akModel.getIsValid()) {
+			throw new ApiKeyException("API Key 已被禁用:" + apiKey).setCode(SaErrorCode.CODE_12302);
+		}
+		if (akModel.getExpiresTime() != -1 && akModel.getExpiresTime() < System.currentTimeMillis()) {
+			throw new ApiKeyException("API Key 已过期:" + apiKey).setCode(SaErrorCode.CODE_12303);
+		}
+		return akModel;
+	}
+
+	public void saveApiKey(ApiKeyModel akModel) {
+		if (akModel == null || SaFoxUtil.isEmpty(akModel.getApiKey())) {
+			throw new ApiKeyException("API Key 不能为空").setCode(SaErrorCode.CODE_12311);
+		}
+		long timeout = akModel.getExpiresTime() == -1 ? -1
+				: (akModel.getExpiresTime() - System.currentTimeMillis()) / 1000;
+		getSaTokenDao().setObject(splicingApiKeySaveKey(akModel.getApiKey()), akModel, timeout);
+		adddApiKeyIndex(akModel);
+	}
+
+	public void deleteApiKey(String apiKey) {
+		ApiKeyModel akModel = getApiKey(apiKey);
+		if (akModel == null) {
+			return;
+		}
+		getSaTokenDao().deleteObject(splicingApiKeySaveKey(apiKey));
+		deleteApiKeyIndex(akModel);
+	}
+
+	@SuppressWarnings("unchecked")
+	public List<String> getApiKeyList(Object loginId) {
+		List<String> list = (List<String>) getSaTokenDao().getObject(splicingApiKeyIndexSaveKey(loginId));
+		return list == null ? new ArrayList<>() : list;
+	}
+
+	public void adddApiKeyIndex(ApiKeyModel akModel) {
+		List<String> list = getApiKeyList(akModel.getLoginId());
+		if (!list.contains(akModel.getApiKey())) {
+			list.add(akModel.getApiKey());
+			getSaTokenDao().setObject(splicingApiKeyIndexSaveKey(akModel.getLoginId()), list, -1);
+		}
+	}
+
+	public void deleteApiKeyIndex(ApiKeyModel akModel) {
+		List<String> list = getApiKeyList(akModel.getLoginId());
+		if (list.contains(akModel.getApiKey())) {
+			list.remove(akModel.getApiKey());
+			getSaTokenDao().setObject(splicingApiKeyIndexSaveKey(akModel.getLoginId()), list, -1);
+		}
+	}
+
+	public String randomApiKeyValue() {
+		return SaSecureUtil.md5(SaFoxUtil.getRandomString(32));
+	}
+
+}

--- a/sa-token-doc/apikey/intro.md
+++ b/sa-token-doc/apikey/intro.md
@@ -1,0 +1,46 @@
+# ApiKey 介绍
+
+ApiKey 是一种常见的开放接口鉴权方案，调用方在请求时携带一个由服务端预先签发的密钥，服务端据此识别调用方身份与权限范围。
+
+Sa-Token 内置了一套完整的 ApiKey 模型，开箱即用，并支持自定义存储与加载逻辑。
+
+
+### 一、基本使用
+
+Sa-Token 提供了 `SaApiKeyUtil` 工具类用于创建、查询、删除 ApiKey。
+
+``` java
+// 创建一个 ApiKey 模型
+ApiKeyModel ak = SaApiKeyUtil.createApiKeyModel();
+
+// 查询指定 ApiKey 的信息
+ApiKeyModel info = SaApiKeyUtil.getApiKey(apiKey);
+
+// 删除指定 ApiKey
+SaApiKeyUtil.deleteApiKey(apiKey);
+```
+
+
+### 二、缓存机制说明
+
+为了减少对底层存储的访问压力，Sa-Token 默认会对 ApiKey 数据进行缓存。理解缓存的生命周期有助于在生产环境中正确使用：
+
+1. `SaApiKeyUtil.getApiKey(apiKey)` 默认会**优先从缓存读取**，命中缓存时不再访问数据源（`SaApiKeyDataLoader`）。
+2. 如果你在框架之外直接修改了底层 ApiKey 存储中的数据（例如：直接修改数据库行记录），在缓存条目过期或被清除之前，这些变更**不会被框架感知**。
+3. 如果希望每次读取都直接走数据源以保证强一致性，可以在自定义的 `SaApiKeyDataLoader` 实现中重写 `getIsAlwaysFromDataLoader()` 方法返回 `true`，此后所有 `getApiKey()` 调用都将绕过缓存。
+4. 如果只是偶尔需要进行一次「新鲜读」，可以使用以下重载方法：
+	- `SaApiKeyUtil.getApiKey(apiKey, false)`：单次查询时绕过缓存。
+	- `SaApiKeyUtil.getApiKeyFromDataLoader(apiKey)`：直接从数据源加载，不读取也不写入缓存。
+
+
+### 三、注意事项
+
+如果你保持默认的「优先读缓存」模式，并在 Sa-Token 框架之外直接修改了 ApiKey 的字段（例如：scope、有效期、关联用户等），请务必在修改完成后手动清除对应的缓存条目：
+
+``` java
+SaApiKeyUtil.deleteApiKey(apiKey);
+```
+
+否则在缓存过期之前，框架仍会使用旧的数据进行鉴权，可能导致权限变更不及时生效。
+
+如果你的业务对一致性要求较高，且无法保证所有变更都通过 `SaApiKeyUtil` 进行，建议直接将 `SaApiKeyDataLoader#getIsAlwaysFromDataLoader()` 重写为返回 `true`，让框架始终从数据源读取。


### PR DESCRIPTION
## Summary

fix: resolve #902 — 对ApiKey的原子性的一些建议

## Problem

**Severity**: `Medium` | **File**: `sa-token-core/src/main/java/cn/dev33/satoken/apikey/loader/SaApiKeyDataLoader.java`

The `SaApiKeyDataLoader` interface is what users implement to load ApiKey data from their own database. Currently the framework caches whatever the loader returns indefinitely (until expiry), and there's no signal to the framework about whether cache should be authoritative. We should add a method (with a default implementation for backward compatibility) that lets the loader declare its cache strategy: always read from data loader, or read-through cache (current behavior).

## Solution

Add a default method like:

## Changes

- `sa-token-core/src/main/java/cn/dev33/satoken/apikey/loader/SaApiKeyDataLoader.java` (new)
- `sa-token-core/src/main/java/cn/dev33/satoken/apikey/template/SaApiKeyTemplate.java` (new)
- `sa-token-core/src/main/java/cn/dev33/satoken/apikey/SaApiKeyUtil.java` (new)
- `sa-token-core/src/main/java/cn/dev33/satoken/annotation/handler/SaCheckApiKeyHandler.java` (new)
- `sa-token-doc/apikey/intro.md` (new)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
*Generated by [ContribAI](https://github.com/tang-vu/ContribAI) v6.8.0*