### PR TITLE
fix: resolve #916 — spring gateway httpstatus状态设置转换异常

### DIFF
--- a/sa-token-starter/sa-token-reactor-spring-boot3-starter/src/main/java/cn/dev33/satoken/reactor/model/SaResponseForReactor.java
+++ b/sa-token-starter/sa-token-reactor-spring-boot3-starter/src/main/java/cn/dev33/satoken/reactor/model/SaResponseForReactor.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2020-2099 sa-token.cc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cn.dev33.satoken.reactor.model;
+
+import cn.dev33.satoken.context.model.SaResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+
+/**
+ * Response for Reactor 
+ *
+ * @author click33
+ * @since 1.34.0
+ */
+public class SaResponseForReactor implements SaResponse {
+
+	/**
+	 * 底层Response对象
+	 */
+	protected ServerHttpResponse response;
+	
+	/**
+	 * 实例化
+	 * @param response response对象 
+	 */
+	public SaResponseForReactor(ServerHttpResponse response) {
+		this.response = response;
+	}
+
+	/**
+	 * 获取底层源对象 
+	 */
+	@Override
+	public Object getSource() {
+		return response;
+	}
+
+	/**
+	 * 设置响应状态码 
+	 */
+	@Override
+	public SaResponse setStatus(int sc) {
+		response.setStatusCode(HttpStatusCode.valueOf(sc));
+		return this;
+	}
+	
+	/**
+	 * 在响应头里写入一个值 
+	 */
+	@Override
+	public SaResponse setHeader(String name, String value) {
+		response.getHeaders().set(name, value);
+		return this;
+	}
+
+	/**
+	 * 在响应头里添加一个值 
+	 */
+	@Override
+	public SaResponse addHeader(String name, String value) {
+		response.getHeaders().add(name, value);
+		return this;
+	}
+
+	/**
+	 * 重定向 
+	 */
+	@Override
+	public SaResponse redirect(String redirectUrl) {
+		response.setStatusCode(HttpStatus.FOUND);
+		response.getHeaders().set("Location", redirectUrl);
+		return this;
+	}
+
+}

--- a/sa-token-starter/sa-token-reactor-spring-boot3-starter/src/test/java/cn/dev33/satoken/reactor/model/SaResponseForReactorTest.java
+++ b/sa-token-starter/sa-token-reactor-spring-boot3-starter/src/test/java/cn/dev33/satoken/reactor/model/SaResponseForReactorTest.java
@@ -1,0 +1,41 @@
+package cn.dev33.satoken.reactor.model;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.http.server.reactive.MockServerHttpResponse;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class SaResponseForReactorTest {
+
+	@Test
+	public void testSetStatusWithStandardCodes() {
+		MockServerHttpResponse mockResponse = new MockServerHttpResponse();
+		SaResponseForReactor saResponse = new SaResponseForReactor(mockResponse);
+
+		saResponse.setStatus(200);
+		assertEquals(200, mockResponse.getStatusCode().value());
+
+		saResponse.setStatus(401);
+		assertEquals(401, mockResponse.getStatusCode().value());
+
+		saResponse.setStatus(500);
+		assertEquals(500, mockResponse.getStatusCode().value());
+	}
+
+	@Test
+	public void testSetStatusWithNonStandardCodes() {
+		MockServerHttpResponse mockResponse = new MockServerHttpResponse();
+		SaResponseForReactor saResponse = new SaResponseForReactor(mockResponse);
+
+		assertDoesNotThrow(() -> saResponse.setStatus(499));
+		assertEquals(499, mockResponse.getStatusCode().value());
+
+		assertDoesNotThrow(() -> saResponse.setStatus(522));
+		assertEquals(522, mockResponse.getStatusCode().value());
+
+		assertDoesNotThrow(() -> saResponse.setStatus(599));
+		assertEquals(599, mockResponse.getStatusCode().value());
+	}
+
+}


### PR DESCRIPTION
## Summary

fix: resolve #916 — spring gateway httpstatus状态设置转换异常

## Problem

**Severity**: `High` | **File**: `sa-token-starter/sa-token-reactor-spring-boot3-starter/src/main/java/cn/dev33/satoken/reactor/model/SaResponseForReactor.java`

The `setStatus(int sc)` method in `SaResponseForReactor` likely uses `HttpStatus.valueOf(sc)` to convert the integer status to a Spring `HttpStatus` enum. This throws an `IllegalArgumentException` (visible in the user's error screenshot) when the code does not match a known enum constant, or fails type conversion in newer Spring versions. For Spring Boot 3.x (which uses `HttpStatusCode` interface introduced in Spring Framework 6), we should use `HttpStatusCode.valueOf(int)` which accepts any integer value and returns either an `HttpStatus` (for standard codes) or a custom implementation (for non-standard codes).

## Solution

Locate the `setStatus(int sc)` method override in `SaResponseForReactor` and change the implementation as follows:

## Changes

- `sa-token-starter/sa-token-reactor-spring-boot3-starter/src/main/java/cn/dev33/satoken/reactor/model/SaResponseForReactor.java` (new)
- `sa-token-starter/sa-token-reactor-spring-boot3-starter/src/test/java/cn/dev33/satoken/reactor/model/SaResponseForReactorTest.java` (new)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
*Generated by [ContribAI](https://github.com/tang-vu/ContribAI) v6.8.0*