### PR TITLE
docs: fix Chinese typo 帐号 -> 账号 in log message

### DIFF
--- a/sa-token-core/src/main/java/cn/dev33/satoken/listener/SaTokenListenerForLog.java
+++ b/sa-token-core/src/main/java/cn/dev33/satoken/listener/SaTokenListenerForLog.java
@@ -116,7 +116,7 @@ public class SaTokenListenerForLog implements SaTokenListener {
 	 */
 	@Override
 	public void doRenewTimeout(String loginType, Object loginId, String tokenValue, long timeout) {
-		log.info("token 续期成功, {} 秒后到期, 帐号={}, token值={} ", timeout, loginId, tokenValue);
+		log.info("token 续期成功, {} 秒后到期, 账号={}, token值={} ", timeout, loginId, tokenValue);
 	}
 
 	/**


### PR DESCRIPTION
## Description
Fix Chinese typo `帐号` → `账号` in a log message string.

File: `sa-token-core/src/main/java/cn/dev33/satoken/listener/SaTokenListenerForLog.java`

According to mainland Chinese language standards, `账号` is the correct form for "account".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>