### PR TITLE
feat: 新增 cache-key-prefix 配置项，支持多项目共用 Redis 时数据隔离

### DIFF
--- a/sa-token-core/src/main/java/cn/dev33/satoken/application/SaApplication.java
+++ b/sa-token-core/src/main/java/cn/dev33/satoken/application/SaApplication.java
@@ -111,7 +111,7 @@ public class SaApplication implements SaSetValueInterface {
 	 * @return 拼接后的 key 值 
 	 */
 	public String splicingDataKey(String key) {
-		return SaManager.getConfig().getTokenName() + ":var:" + key;
+		return SaManager.getConfig().splicingCacheKeyPrefix() + ":var:" + key;
 	}
 	
 }

--- a/sa-token-core/src/main/java/cn/dev33/satoken/config/SaTokenConfig.java
+++ b/sa-token-core/src/main/java/cn/dev33/satoken/config/SaTokenConfig.java
@@ -163,6 +163,12 @@ public class SaTokenConfig implements Serializable {
 	private String tokenPrefix;
 
 	/**
+	 * 持久层数据 key 的公共前缀，用于多个项目共用同一个 Redis 时做数据隔离。
+	 * <br/> 例如配置为 {@code example} 后，token 存储 key 将变为 {@code example:satoken:login:token:xxx}。
+	 */
+	private String cacheKeyPrefix = "";
+
+	/**
 	 * cookie 模式是否自动填充 token 前缀
 	 */
 	private Boolean cookieAutoFillPrefix = false;
@@ -519,6 +525,35 @@ public class SaTokenConfig implements Serializable {
 	public SaTokenConfig setTokenPrefix(String tokenPrefix) {
 		this.tokenPrefix = tokenPrefix;
 		return this;
+	}
+
+	/**
+	 * @return 持久层数据 key 的公共前缀
+	 */
+	public String getCacheKeyPrefix() {
+		return cacheKeyPrefix;
+	}
+
+	/**
+	 * @param cacheKeyPrefix 持久层数据 key 的公共前缀
+	 * @return 对象自身
+	 */
+	public SaTokenConfig setCacheKeyPrefix(String cacheKeyPrefix) {
+		this.cacheKeyPrefix = cacheKeyPrefix;
+		return this;
+	}
+
+	/**
+	 * 拼接：持久层数据 key 的统一前缀（cacheKeyPrefix + tokenName）。
+	 * <br/> 如果未配置 cacheKeyPrefix，则只返回 tokenName，保持与旧版本一致。
+	 *
+	 * @return /
+	 */
+	public String splicingCacheKeyPrefix() {
+		if (SaFoxUtil.isEmpty(cacheKeyPrefix)) {
+			return tokenName;
+		}
+		return cacheKeyPrefix + ":" + tokenName;
 	}
 
 	/**
@@ -900,6 +935,7 @@ public class SaTokenConfig implements Serializable {
 				+ ", tokenSessionCheckLogin=" + tokenSessionCheckLogin
 				+ ", autoRenew=" + autoRenew
 				+ ", tokenPrefix=" + tokenPrefix
+				+ ", cacheKeyPrefix=" + cacheKeyPrefix
 				+ ", cookieAutoFillPrefix=" + cookieAutoFillPrefix
 				+ ", isPrint=" + isPrint 
 				+ ", isLog=" + isLog 

--- a/sa-token-core/src/main/java/cn/dev33/satoken/same/SaSameTemplate.java
+++ b/sa-token-core/src/main/java/cn/dev33/satoken/same/SaSameTemplate.java
@@ -176,7 +176,7 @@ public class SaSameTemplate {
 	 * @return key
 	 */
 	public String splicingTokenSaveKey() {
-		return SaManager.getConfig().getTokenName() + ":var:same-token";
+		return SaManager.getConfig().splicingCacheKeyPrefix() + ":var:same-token";
 	}
 
 	/** 
@@ -184,7 +184,7 @@ public class SaSameTemplate {
 	 * @return key
 	 */
 	public String splicingPastTokenSaveKey() {
-		return SaManager.getConfig().getTokenName() + ":var:past-same-token";
+		return SaManager.getConfig().splicingCacheKeyPrefix() + ":var:past-same-token";
 	}
 
 }

--- a/sa-token-core/src/main/java/cn/dev33/satoken/session/SaSessionCustomUtil.java
+++ b/sa-token-core/src/main/java/cn/dev33/satoken/session/SaSessionCustomUtil.java
@@ -54,7 +54,7 @@ public class SaSessionCustomUtil {
 	 * @return sessionId
 	 */
 	public static String splicingSessionKey(String sessionId) {
-		return SaManager.getConfig().getTokenName() + ":" + sessionKey + ":session:" + sessionId;
+		return SaManager.getConfig().splicingCacheKeyPrefix() + ":" + sessionKey + ":session:" + sessionId;
 	}
 
 	/**

--- a/sa-token-core/src/main/java/cn/dev33/satoken/session/raw/SaRawSessionUtil.java
+++ b/sa-token-core/src/main/java/cn/dev33/satoken/session/raw/SaRawSessionUtil.java
@@ -38,7 +38,7 @@ public class SaRawSessionUtil {
 	 * @return sessionId
 	 */
 	public static String splicingSessionKey(String type, Object valueId) {
-		return SaManager.getConfig().getTokenName() + ":raw-session:" + type + ":" + valueId;
+		return SaManager.getConfig().splicingCacheKeyPrefix() + ":raw-session:" + type + ":" + valueId;
 	}
 
 	/**

--- a/sa-token-core/src/main/java/cn/dev33/satoken/stp/StpLogic.java
+++ b/sa-token-core/src/main/java/cn/dev33/satoken/stp/StpLogic.java
@@ -3043,7 +3043,7 @@ public class StpLogic {
 	 * @return key
 	 */
 	public String splicingKeyTokenValue(String tokenValue) {
-		return getConfigOrGlobal().getTokenName() + ":" + loginType + ":token:" + tokenValue;
+		return getConfigOrGlobal().splicingCacheKeyPrefix() + ":" + loginType + ":token:" + tokenValue;
 	}
 
 	/**
@@ -3053,7 +3053,7 @@ public class StpLogic {
 	 * @return key
 	 */
 	public String splicingKeySession(Object loginId) {
-		return getConfigOrGlobal().getTokenName() + ":" + loginType + ":session:" + loginId;
+		return getConfigOrGlobal().splicingCacheKeyPrefix() + ":" + loginType + ":session:" + loginId;
 	}
 
 	/**
@@ -3063,7 +3063,7 @@ public class StpLogic {
 	 * @return key
 	 */
 	public String splicingKeyTokenSession(String tokenValue) {
-		return getConfigOrGlobal().getTokenName() + ":" + loginType + ":token-session:" + tokenValue;
+		return getConfigOrGlobal().splicingCacheKeyPrefix() + ":" + loginType + ":token-session:" + tokenValue;
 	}
 
 	/**
@@ -3073,7 +3073,7 @@ public class StpLogic {
 	 * @return key
 	 */
 	public String splicingKeyLastActiveTime(String tokenValue) {
-		return getConfigOrGlobal().getTokenName() + ":" + loginType + ":last-active:" + tokenValue;
+		return getConfigOrGlobal().splicingCacheKeyPrefix() + ":" + loginType + ":last-active:" + tokenValue;
 	}
 
 	/**
@@ -3103,7 +3103,7 @@ public class StpLogic {
 	 * @return key
 	 */
 	public String splicingKeyDisable(Object loginId, String service) {
-		return getConfigOrGlobal().getTokenName() + ":" + loginType + ":disable:" + service + ":" + loginId;
+		return getConfigOrGlobal().splicingCacheKeyPrefix() + ":" + loginType + ":disable:" + service + ":" + loginId;
 	}
 
 	/**
@@ -3116,7 +3116,7 @@ public class StpLogic {
 	public String splicingKeySafe(String tokenValue, String service) {
 		// 格式：<Token名称>:<账号类型>:<safe>:<业务标识>:<Token值>
 		// 形如：satoken:login:safe:important:gr_SwoIN0MC1ewxHX_vfCW3BothWDZMMtx__
-		return getConfigOrGlobal().getTokenName() + ":" + loginType + ":safe:" + service + ":" + tokenValue;
+		return getConfigOrGlobal().splicingCacheKeyPrefix() + ":" + loginType + ":safe:" + service + ":" + tokenValue;
 	}
 
 

--- a/sa-token-core/src/main/java/cn/dev33/satoken/temp/SaTempTemplate.java
+++ b/sa-token-core/src/main/java/cn/dev33/satoken/temp/SaTempTemplate.java
@@ -363,7 +363,7 @@ public class SaTempTemplate implements SaTtlMethods {
 	 * @return key
 	 */
 	public String splicingTempTokenSaveKey(String token) {
-		return SaManager.getConfig().getTokenName() + ":" + namespace + ":" + token;
+		return SaManager.getConfig().splicingCacheKeyPrefix() + ":" + namespace + ":" + token;
 	}
 
 	/**

--- a/sa-token-doc/arch/data-structure.md
+++ b/sa-token-doc/arch/data-structure.md
@@ -1,5 +1,7 @@
 # 数据结构
 
+> 说明：下文所列 key 均默认未配置 `cache-key-prefix`。当配置了 `sa-token.cache-key-prefix` 后，所有 key 最前面会再拼接上 `{cacheKeyPrefix}:`。
+
 
 ## 1、登录会话
 

--- a/sa-token-doc/more/common-questions.md
+++ b/sa-token-doc/more/common-questions.md
@@ -864,6 +864,7 @@ SaHolder.getResponse().setStatus(401)
 - 方式 1：使用不同的 db 索引，Redis 默认提供 16 个 database 容器，每个项目配置不同的 db 索引即可。
 - 方式 2：给项目配置不同的 `sa-token.token-name` 值，此配置项默认为 `satoken`，是框架在 Redis 存储数据时使用的统一前缀。
 - 方式 3：使用 `sa-token-three-redis-jackson-add-prefix` 插件，参考：[sa-token-three-plugin](https://gitee.com/sa-tokens/sa-token-three-plugin)。
+- 方式 4（v1.46.0+）：给项目配置不同的 `sa-token.cache-key-prefix` 值，例如 `example`，此时 Redis 中 key 会变为 `example:satoken:login:token:xxx`，且不会影响前端提交的 token 名称。
 
 
 ### Q：如何防止 CSRF 攻击？

--- a/sa-token-doc/more/update-log.md
+++ b/sa-token-doc/more/update-log.md
@@ -1,5 +1,14 @@
 # 更新日志 
 
+### v1.46.0 @TODO
+- core：
+	- 新增：新增 `sa-token.cache-key-prefix` 配置项，支持为所有 token、session 等持久层 key 添加项目级公共前缀，方便多个项目共用同一个 Redis 时进行数据隔离。merge: [issue 956](https://github.com/dromara/Sa-Token/issues/956)
+	- 新增：为 `cache-key-prefix` 添加相关单元测试与集成测试。
+- 文档：
+	- 新增：在配置文档中补充 `cache-key-prefix` 配置项说明。
+	- 新增：在常见问题中补充“多个项目共用同一个 redis，怎么防止冲突？”的解决方案。
+	- 优化：数据结构文档增加 `cache-key-prefix` 前缀相关说明。
+
 ### v1.45.0 @2026-3-8
 - core：
 	- 新增：新增重复登录处理策略，当同一账号不允许多客户端同时登录时支持选择踢人下线或拦截本次登录。  **[重要]** merge: [pr 349](https://gitee.com/dromara/sa-token/pulls/349)

--- a/sa-token-doc/use/config.md
+++ b/sa-token-doc/use/config.md
@@ -143,6 +143,7 @@ public class SaTokenConfigure {
 | tokenSessionCheckLogin	| Boolean	| true	| 获取 `Token-Session` 时是否必须登录 （如果配置为true，会在每次获取 `Token-Session` 时校验是否登录），[详解](/use/config?id=配置项详解：tokenSessionCheckLogin)		|
 | autoRenew				| Boolean	| true		| 是否打开自动续签 （如果此值为true，框架会在每次直接或间接调用 `getLoginId()` 时进行一次过期检查与续签操作），[参考：token有效期详解](/fun/token-timeout)		|
 | tokenPrefix			| String	| null		| token前缀，例如填写 `Bearer` 实际传参 `satoken: Bearer xxxx-xxxx-xxxx-xxxx` 	[参考：自定义Token前缀](/up/token-prefix) 			|
+| cacheKeyPrefix		| String	| "" 		| 持久层数据 key 的公共前缀，多个项目共用 Redis 时可通过不同前缀隔离数据，例如配置 `example` 后 key 变为 `example:satoken:login:token:xxx` |
 | cookieAutoFillPrefix	| Boolean	| false		| cookie 模式是否自动填充 token 提交前缀				|
 | isPrint				| Boolean	| true		| 是否在初始化配置时打印版本字符画													|
 | isLog					| Boolean	| false		| 是否打印操作日志																	|

--- a/sa-token-plugin/sa-token-apikey/src/main/java/cn/dev33/satoken/apikey/template/SaApiKeyTemplate.java
+++ b/sa-token-plugin/sa-token-apikey/src/main/java/cn/dev33/satoken/apikey/template/SaApiKeyTemplate.java
@@ -526,7 +526,7 @@ public class SaApiKeyTemplate {
 	 * @return key
 	 */
 	public String splicingApiKeySaveKey(String apiKey) {
-		return getSaTokenConfig().getTokenName() + ":" + namespace + ":" + apiKey;
+		return getSaTokenConfig().splicingCacheKeyPrefix() + ":" + namespace + ":" + apiKey;
 	}
 
 

--- a/sa-token-plugin/sa-token-oauth2/src/main/java/cn/dev33/satoken/oauth2/dao/SaOAuth2Dao.java
+++ b/sa-token-plugin/sa-token-oauth2/src/main/java/cn/dev33/satoken/oauth2/dao/SaOAuth2Dao.java
@@ -726,7 +726,7 @@ public class SaOAuth2Dao implements SaTtlMethods {
 	 * @return key
 	 */
 	public String splicingCodeSaveKey(String code) {
-		return getSaTokenConfig().getTokenName() + ":oauth2:code:" + code;
+		return getSaTokenConfig().splicingCacheKeyPrefix() + ":oauth2:code:" + code;
 	}
 
 	/**
@@ -736,7 +736,7 @@ public class SaOAuth2Dao implements SaTtlMethods {
 	 * @return key
 	 */
 	public String splicingCodeIndexKey(String clientId, Object loginId) {
-		return getSaTokenConfig().getTokenName() + ":oauth2:code-index:" + clientId + ":" + loginId;
+		return getSaTokenConfig().splicingCacheKeyPrefix() + ":oauth2:code-index:" + clientId + ":" + loginId;
 	}
 
 	/**
@@ -745,7 +745,7 @@ public class SaOAuth2Dao implements SaTtlMethods {
 	 * @return key
 	 */
 	public String splicingAccessTokenSaveKey(String accessToken) {
-		return getSaTokenConfig().getTokenName() + ":oauth2:access-token:" + accessToken;
+		return getSaTokenConfig().splicingCacheKeyPrefix() + ":oauth2:access-token:" + accessToken;
 	}
 
 	/**
@@ -764,7 +764,7 @@ public class SaOAuth2Dao implements SaTtlMethods {
 	 * @return key
 	 */
 	public String splicingRefreshTokenSaveKey(String refreshToken) {
-		return getSaTokenConfig().getTokenName() + ":oauth2:refresh-token:" + refreshToken;
+		return getSaTokenConfig().splicingCacheKeyPrefix() + ":oauth2:refresh-token:" + refreshToken;
 	}
 
 	/**
@@ -783,7 +783,7 @@ public class SaOAuth2Dao implements SaTtlMethods {
 	 * @return key
 	 */
 	public String splicingClientTokenSaveKey(String clientToken) {
-		return getSaTokenConfig().getTokenName() + ":oauth2:client-token:" + clientToken;
+		return getSaTokenConfig().splicingCacheKeyPrefix() + ":oauth2:client-token:" + clientToken;
 	}
 
 	/**
@@ -802,7 +802,7 @@ public class SaOAuth2Dao implements SaTtlMethods {
 	 * @return key
 	 */
 	public String splicingGrantScopeKey(String clientId, Object loginId) {
-		return getSaTokenConfig().getTokenName() + ":oauth2:grant-scope:" + clientId + ":" + loginId;
+		return getSaTokenConfig().splicingCacheKeyPrefix() + ":oauth2:grant-scope:" + clientId + ":" + loginId;
 	}
 
 	/**
@@ -811,7 +811,7 @@ public class SaOAuth2Dao implements SaTtlMethods {
 	 * @return key
 	 */
 	public String splicingStateSaveKey(String state) {
-		return getSaTokenConfig().getTokenName() + ":oauth2:state:" + state;
+		return getSaTokenConfig().splicingCacheKeyPrefix() + ":oauth2:state:" + state;
 	}
 
 	/**
@@ -820,7 +820,7 @@ public class SaOAuth2Dao implements SaTtlMethods {
 	 * @return key
 	 */
 	public String splicingCodeNonceIndexSaveKey(String code) {
-		return getSaTokenConfig().getTokenName() + ":oauth2:code-nonce-index:" + code;
+		return getSaTokenConfig().splicingCacheKeyPrefix() + ":oauth2:code-nonce-index:" + code;
 	}
 
 

--- a/sa-token-plugin/sa-token-sign/src/main/java/cn/dev33/satoken/sign/template/SaSignTemplate.java
+++ b/sa-token-plugin/sa-token-sign/src/main/java/cn/dev33/satoken/sign/template/SaSignTemplate.java
@@ -410,7 +410,7 @@ public class SaSignTemplate {
 	 * @return key
 	 */
 	public String splicingNonceSaveKey(String nonce) {
-		return SaManager.getConfig().getTokenName() + ":sign:nonce:" + nonce;
+		return SaManager.getConfig().splicingCacheKeyPrefix() + ":sign:nonce:" + nonce;
 	}
 
 }

--- a/sa-token-plugin/sa-token-sso/src/main/java/cn/dev33/satoken/sso/template/SaSsoServerTemplate.java
+++ b/sa-token-plugin/sa-token-sso/src/main/java/cn/dev33/satoken/sso/template/SaSsoServerTemplate.java
@@ -807,7 +807,7 @@ public class SaSsoServerTemplate extends SaSsoTemplate {
      * @return key
      */
     public String splicingTicketModelSaveKey(String ticket) {
-        return getStpLogicOrGlobal().getConfigOrGlobal().getTokenName() + ":ticket:" + ticket;
+        return getStpLogicOrGlobal().getConfigOrGlobal().splicingCacheKeyPrefix() + ":ticket:" + ticket;
     }
 
     /**
@@ -821,7 +821,7 @@ public class SaSsoServerTemplate extends SaSsoTemplate {
         if(SaFoxUtil.isEmpty(client) || SaSsoConsts.CLIENT_WILDCARD.equals(client)) {
             client = SaSsoConsts.CLIENT_ANON;
         }
-        return getStpLogicOrGlobal().getConfigOrGlobal().getTokenName() + ":ticket-index:" + client + ":" + id;
+        return getStpLogicOrGlobal().getConfigOrGlobal().splicingCacheKeyPrefix() + ":ticket-index:" + client + ":" + id;
     }
 
 }

--- a/sa-token-test/sa-token-springboot-test/src/test/java/cn/dev33/satoken/core/config/SaTokenConfigTest.java
+++ b/sa-token-test/sa-token-springboot-test/src/test/java/cn/dev33/satoken/core/config/SaTokenConfigTest.java
@@ -77,6 +77,16 @@ public class SaTokenConfigTest {
 		config.setTokenPrefix("token");
 		Assertions.assertEquals(config.getTokenPrefix(), "token");
 
+		config.setCacheKeyPrefix("example");
+		Assertions.assertEquals(config.getCacheKeyPrefix(), "example");
+		Assertions.assertEquals(config.splicingCacheKeyPrefix(), "example:nav-token");
+
+		config.setCacheKeyPrefix("");
+		Assertions.assertEquals(config.splicingCacheKeyPrefix(), "nav-token");
+
+		config.setCacheKeyPrefix(null);
+		Assertions.assertEquals(config.splicingCacheKeyPrefix(), "nav-token");
+
 		config.setIsPrint(false);
 		Assertions.assertEquals(config.getIsPrint(), false);
 
@@ -115,6 +125,8 @@ public class SaTokenConfigTest {
 		Assertions.assertEquals(config.getIsConcurrent(), false);
 		Assertions.assertEquals(config.getIsShare(), false);
 		Assertions.assertEquals(config.getIsLog(), true);
+		Assertions.assertEquals(config.getCacheKeyPrefix(), "example");
+		Assertions.assertEquals(config.splicingCacheKeyPrefix(), "example:use-token");
 	}
 
 	// 测试 SaCookieConfig 

--- a/sa-token-test/sa-token-springboot-test/src/test/java/cn/dev33/satoken/springboot/BasicsTest.java
+++ b/sa-token-test/sa-token-springboot-test/src/test/java/cn/dev33/satoken/springboot/BasicsTest.java
@@ -100,47 +100,81 @@ public class BasicsTest {
     	Assertions.assertEquals(SaManager.getStpLogic("login"), loginStpLogic);
     }
     
-    // 测试：登录 
+    // 测试：登录
     @Test
     public void testDoLogin() {
     	// 登录
     	StpUtil.login(10001);
     	String token = StpUtil.getTokenValue();
-    	
-    	// token 存在 
+
+    	// token 存在
     	Assertions.assertNotNull(token);
     	Assertions.assertEquals(token, StpUtil.getTokenValueNotCut());
     	Assertions.assertEquals(token, StpUtil.getTokenValueByLoginId(10001));
     	Assertions.assertEquals(token, StpUtil.getTokenValueByLoginId(10001, SaTokenConsts.DEFAULT_LOGIN_DEVICE_TYPE));
-    	
-    	// token 队列 
+
+    	// token 队列
     	List<String> tokenList = StpUtil.getTokenValueListByLoginId(10001);
     	List<String> tokenList2 = StpUtil.getTokenValueListByLoginId(10001, SaTokenConsts.DEFAULT_LOGIN_DEVICE_TYPE);
     	Assertions.assertEquals(token, tokenList.get(tokenList.size() - 1));
     	Assertions.assertEquals(token, tokenList2.get(tokenList.size() - 1));
-    	
-    	// API 验证 
-    	Assertions.assertTrue(StpUtil.isLogin());	
+
+    	// API 验证
+    	Assertions.assertTrue(StpUtil.isLogin());
     	Assertions.assertDoesNotThrow(() -> StpUtil.checkLogin());
     	Assertions.assertNotNull(token);	// token不为null
-    	Assertions.assertEquals(StpUtil.getLoginIdAsLong(), 10001);	// loginId=10001 
-    	Assertions.assertEquals(StpUtil.getLoginIdAsInt(), 10001);	// loginId=10001 
-    	Assertions.assertEquals(StpUtil.getLoginIdAsString(), "10001");	// loginId=10001 
-    	Assertions.assertEquals(StpUtil.getLoginId(), "10001");	// loginId=10001 
-    	Assertions.assertEquals(StpUtil.getLoginIdDefaultNull(), "10001");	// loginId=10001 
+    	Assertions.assertEquals(StpUtil.getLoginIdAsLong(), 10001);	// loginId=10001
+    	Assertions.assertEquals(StpUtil.getLoginIdAsInt(), 10001);	// loginId=10001
+    	Assertions.assertEquals(StpUtil.getLoginIdAsString(), "10001");	// loginId=10001
+    	Assertions.assertEquals(StpUtil.getLoginId(), "10001");	// loginId=10001
+    	Assertions.assertEquals(StpUtil.getLoginIdDefaultNull(), "10001");	// loginId=10001
     	Assertions.assertEquals(StpUtil.getLoginDevice(), SaTokenConsts.DEFAULT_LOGIN_DEVICE_TYPE);	// 登录设备类型
-    	
-    	// db数据 验证  
-    	// token存在 
+
+    	// db数据 验证
+    	// token存在
     	Assertions.assertEquals(dao.get("satoken:login:token:" + token), "10001");
-    	// Session 存在 
+    	// Session 存在
     	SaSession session = dao.getSession("satoken:login:session:" + 10001);
     	Assertions.assertNotNull(session);
     	Assertions.assertEquals(session.getId(), "satoken:login:session:" + 10001);
     	Assertions.assertTrue(session.getTerminalList().size() >= 1);
     }
-    
-    // 测试：注销 
+
+    // 测试：cacheKeyPrefix 对 Redis key 的影响
+    @Test
+    public void testCacheKeyPrefix() {
+    	// 备份原配置
+    	String oldCacheKeyPrefix = SaManager.getConfig().getCacheKeyPrefix();
+
+    	try {
+    		// 设置项目级公共前缀
+    		SaManager.getConfig().setCacheKeyPrefix("project-a");
+
+    		// 登录
+    		StpUtil.login(10001);
+    		String token = StpUtil.getTokenValue();
+
+    		// tokenName 不应该受 cacheKeyPrefix 影响
+    		Assertions.assertEquals(StpUtil.getTokenName(), "satoken");
+
+    		// Redis 中的 key 应该带有 project-a 前缀
+    		Assertions.assertEquals(dao.get("project-a:satoken:login:token:" + token), "10001");
+
+    		// Session key 也应该带有前缀
+    		SaSession session = dao.getSession("project-a:satoken:login:session:" + 10001);
+    		Assertions.assertNotNull(session);
+    		Assertions.assertEquals(session.getId(), "project-a:satoken:login:session:" + 10001);
+
+    		// 注销，验证清理也走前缀 key
+    		StpUtil.logout();
+    		Assertions.assertNull(dao.get("project-a:satoken:login:token:" + token));
+    	} finally {
+    		// 恢复配置
+    		SaManager.getConfig().setCacheKeyPrefix(oldCacheKeyPrefix);
+    	}
+    }
+
+    // 测试：注销
     @Test
     public void testLogout() {
     	// 登录

--- a/sa-token-test/sa-token-springboot-test/src/test/resources/sa-token2.properties
+++ b/sa-token-test/sa-token-springboot-test/src/test/resources/sa-token2.properties
@@ -10,3 +10,5 @@ isConcurrent=false
 isShare=false
 # 是否输出操作日志 
 isLog=true
+# 持久层数据 key 的公共前缀
+cacheKeyPrefix=example


### PR DESCRIPTION
 ## 说明                                                                                                                                                     207,097 tokens                          
     实现 #956 需求：为所有 token 和 session 等持久层数据 key 增加可自定义的项目级公共前缀。                                                                     79% used                                
                                                                                                                                                                 $2.09 spent                             
     ## 使用方式                                                                                                                                                                                         
     在 `application.yml` 中配置：                                                                                                                               LSP                                     
     ```yaml                                                                                                                                                     LSPs are disabled                       
     sa-token:                                                                                                                                                                                           
         cache-key-prefix: example                                                                                                                                                                       
                                                                                                                                                                                                         
     配置后 Redis 中的 key 将从 satoken:login:token:xxx 变为 example:satoken:login:token:xxx。                                                                                                           
                                                                                                                                                                                                         
     主要改动                                                                                                                                                                                            
                                                                                                                                                                                                         
     - SaTokenConfig：新增 cacheKeyPrefix 字段与 splicingCacheKeyPrefix() 方法                                                                                                                           
     - StpLogic：token、session、token-session、last-active、disable、safe 等 key 统一加前缀                                                                                                             
     - SaApplication、SaSessionCustomUtil、SaRawSessionUtil、SaSameTemplate、SaTempTemplate：相应 key 加前缀                                                                                             
     - 插件模块：sa-token-sso、sa-token-oauth2、sa-token-sign、sa-token-apikey 等 key 加前缀                                                                                                             
     - 新增单元测试和集成测试                                                                                                                                                                            
     - 更新配置文档、常见问题、数据结构说明、更新日志                                                                                                                                                    
                                                                                                                                                                                                         
     设计要点                                                                                                                                                                                            
                                                                                                                                                                                                         
     - 默认值为空字符串，不配置时与旧版本完全兼容                                                                                                                                                        
     - 只影响持久层 key，不影响前端提交的 tokenName                                                                                                                                                      
     - 通过 splicingCacheKeyPrefix() 统一拼接，避免遗漏                                                                                                                                                                                                                                                                                                                                                           
     测试                                                                                                                                                                                                
                                                                                                                                                                                                         
     - 已通过 mvn -f sa-token-test/pom.xml -pl sa-token-springboot-test -am test                                                                                                                         
     - 测试结果：Tests run: 114, Failures: 0, Errors: 0, Skipped: 0                                                                                                                                      
                                                                                                                                                                                                         
     Closes #956                                                        