### PR TITLE
docs: 修复 README 中三个 SSO 模式示例链接 404 的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,9 +169,9 @@ Sa-Token SSO 分为三种模式，可解决：`同域、跨域、共享Redis、�
 
 | 系统架构						| 采用模式	| 简介						        |  文档链接	|
 | :--------						| :--------	|:----------------| :--------	|
-| 前端同域 + 后端同 Redis			| 模式一		| 共享Cookie同步会话			 | [文档](https://sa-token.com/doc.html#/sso/sso-type1)、[示例](https://gitee.com/dromara/sa-token/blob/master/sa-token-demo/sa-token-demo-sso1-client)	|
-| 前端不同域 + 后端同 Redis		| 模式二		| URL重定向传播会话 			  | [文档](https://sa-token.com/doc.html#/sso/sso-type2)、[示例](https://gitee.com/dromara/sa-token/blob/master/sa-token-demo/sa-token-demo-sso2-client)	|
-| 前端不同域 + 后端 不同Redis		| 模式三		| HTTP请求获取会话			   | [文档](https://sa-token.com/doc.html#/sso/sso-type3)、[示例](https://gitee.com/dromara/sa-token/blob/master/sa-token-demo/sa-token-demo-sso3-client)	|
+| 前端同域 + 后端同 Redis			| 模式一		| 共享Cookie同步会话			 | [文档](https://sa-token.com/doc.html#/sso/sso-type1)、[示例](https://gitee.com/dromara/sa-token/blob/master/sa-token-demo/sa-token-demo-sso/sa-token-demo-sso1-client)	|
+| 前端不同域 + 后端同 Redis		| 模式二		| URL重定向传播会话 			  | [文档](https://sa-token.com/doc.html#/sso/sso-type2)、[示例](https://gitee.com/dromara/sa-token/blob/master/sa-token-demo/sa-token-demo-sso/sa-token-demo-sso2-client)	|
+| 前端不同域 + 后端 不同Redis		| 模式三		| HTTP请求获取会话			   | [文档](https://sa-token.com/doc.html#/sso/sso-type3)、[示例](https://gitee.com/dromara/sa-token/blob/master/sa-token-demo/sa-token-demo-sso/sa-token-demo-sso3-client)	|
 
 
 1. 前端同域：就是指多个系统可以部署在同一个主域名之下，比如：`c1.domain.com`、`c2.domain.com`、`c3.domain.com`


### PR DESCRIPTION
### 修复内容

README.md 第 172-174 行（SSO 三种模式表格）中的三个"示例"链接指向 gitee 旧路径，均已 404。原因是 SSO demo 目录已重组至 `sa-token-demo/sa-token-demo-sso/` 子目录下，README 链接缺少这一层级。

本 PR 为三个链接补充 `sa-token-demo-sso/` 目录层级。

### 关联 Issue

Fixes #974

### 验证方式

以下为修复后链接，已逐一验证可正常访问（HTTP 200）：

- https://gitee.com/dromara/sa-token/blob/master/sa-token-demo/sa-token-demo-sso/sa-token-demo-sso1-client
- https://gitee.com/dromara/sa-token/blob/master/sa-token-demo/sa-token-demo-sso/sa-token-demo-sso2-client
- https://gitee.com/dromara/sa-token/blob/master/sa-token-demo/sa-token-demo-sso/sa-token-demo-sso3-client

旧链接（未修复前）均返回 404。

### 改动范围

仅 README.md，3 行 URL 修正，纯文档改动，无代码影响。